### PR TITLE
Introduce concept of a synchronization unit that will supersede the management room.

### DIFF
--- a/src/models/PolicyList.ts
+++ b/src/models/PolicyList.ts
@@ -33,18 +33,6 @@ import AwaitLock from "await-lock";
 import { monotonicFactory } from "ulidx";
 
 /**
- * Account data event type used to store the permalinks to each of the policylists.
- *
- * Content:
- * ```jsonc
- * {
- *   references: string[], // Each entry is a `matrix.to` permalink.
- * }
- * ```
- */
-export const WATCHED_LISTS_EVENT_TYPE = "org.matrix.mjolnir.watched_lists";
-
-/**
  * A prefix used to record that we have already warned at least once that a PolicyList room is unprotected.
  */
 export const WARN_UNPROTECTED_ROOM_EVENT_PREFIX = "org.matrix.mjolnir.unprotected_room_warning.for.";


### PR DESCRIPTION
The management room will basically become a "synchronization unit". Synchronization units will work in a similar way as policy lists but will determine how different policy lists will be applied to rooms. In a consistent way.

The idea for this is not really solve problems such as "how do i moderate these two spaces differently". More how do we talk about how policy lists are "watched" by rooms and how policies get applied. The idea is to try get to a situation where policies can be applied from lists arbitrarily (with a modular plugin system within Draupnir somewhat like a protection). At the least it opens up room for some immediate UX improvements (by allowing clients to introspect Draupnir directly). 

This PR isn't ready. This isn't the only change going to land on this branch. 