### PR TITLE
Deprecate `config.verboseLogging`

### DIFF
--- a/config/default.yaml
+++ b/config/default.yaml
@@ -51,9 +51,11 @@ recordIgnoredInvites: false
 # (see verboseLogging to adjust this a bit.)
 managementRoom: "#moderators:example.org"
 
+# Deprecated and will be removed in a future version.
+# Running with verboseLogging is unsupported.
 # Whether Draupnir should log a lot more messages in the room,
 # mainly involves "all-OK" messages, and debugging messages for when draupnir checks bans in a room.
-verboseLogging: true
+verboseLogging: false
 
 # The log level of terminal (or container) output,
 # can be one of DEBUG, INFO, WARN and ERROR, in increasing order of importance and severity.

--- a/config/harness.yaml
+++ b/config/harness.yaml
@@ -47,8 +47,12 @@ recordIgnoredInvites: false
 # Note: Mjolnir is fairly verbose - expect a lot of messages from it.
 managementRoom: "#moderators:localhost:9999"
 
-# Set to false to make the management room a bit quieter.
-verboseLogging: true
+# Deprecated and will be removed in a future version.
+# Running with verboseLogging is unsupported.
+# Whether Draupnir should log a lot more messages in the room,
+# mainly involves "all-OK" messages, and debugging messages for when draupnir checks bans in a room.
+verboseLogging: false
+
 
 # The log level for the logs themselves. One of DEBUG, INFO, WARN, and ERROR.
 # This should be at INFO or DEBUG in order to get support for Mjolnir problems.

--- a/src/Mjolnir.ts
+++ b/src/Mjolnir.ts
@@ -336,6 +336,9 @@ export class Mjolnir {
 
             this.currentState = STATE_RUNNING;
             await this.managementRoomOutput.logMessage(LogLevel.INFO, "Mjolnir@startup", "Startup complete. Now monitoring rooms.");
+            if (this.config.verboseLogging) {
+                await this.managementRoomOutput.logMessage(LogLevel.WARN, "Mjolnir@startup", "The use of verbose logging is deprecated and will be removed in a future version, check your config.");
+            }
         } catch (err) {
             try {
                 LogService.error("Mjolnir", "Error during startup:", err);


### PR DESCRIPTION
Shouldn't change what is being logged to the log file, but it does change what gets sent to the management room. I've been meaning to disable this for some time as it generally confuses new users and it makes the bot feel very confusing and low quality. It also means you are likely to miss more important messages in the magement room.

Another problem it causes is an inconsistent view when testing the software and it's an unreasonable burden to test for both settings.

It's not clear what the value of this setting is apart from providing comfort to some users who want to see the ACL readout. But even then it's a very inefficient way of doing that, so i'd rather another feature be requested by users that want to see that.