### PR TITLE
Only CommandExceptions should log at creation.

### DIFF
--- a/src/commands/interface-manager/CommandException.ts
+++ b/src/commands/interface-manager/CommandException.ts
@@ -32,6 +32,7 @@ export class CommandException extends CommandError {
         public readonly exception: Error|unknown,
         message: string) {
         super(message)
+        this.log();
     }
 
     public static Result<Ok>(message: string, options: { exception: Error, exceptionKind: CommandExceptionKind }): CommandResult<Ok, CommandException> {

--- a/src/commands/interface-manager/Validation.ts
+++ b/src/commands/interface-manager/Validation.ts
@@ -24,7 +24,6 @@ limitations under the License.
  * However, this file is modified and the modifications in this file
  * are NOT distributed, contributed, committed, or licensed under the Apache License.
  */
-import { LogService } from "matrix-bot-sdk";
 
 type ValidationMatchExpression<Ok, Err> = { ok?: (ok: Ok) => any, err?: (err: Err) => any};
 
@@ -90,7 +89,7 @@ export class CommandError {
     public constructor(
         public readonly message: string,
     ) {
-        this.log();
+        // nothing to do.
     }
 
     /**
@@ -101,9 +100,5 @@ export class CommandError {
      */
     public static Result<Ok>(message: string, _options = {}): CommandResult<Ok> {
         return CommandResult.Err(new CommandError(message));
-    }
-
-    protected log(): void {
-        LogService.info("CommandError", this.message);
     }
 }


### PR DESCRIPTION
Before CommandError's where and they are used
liberally for validating command arguments by
returning a CommandResult for several possible
options. Which gives a lot of spam. It's not necessary anyways since these should only be used for known errors.