### PR TITLE
dependabot.yml: rename everything to github-actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,6 +13,6 @@ updates:
     schedule:
       interval: "daily"
     groups:
-      everything:
+      github-actions:
         patterns:
           - "*"


### PR DESCRIPTION
I didn't know the "everything" would be visible in PR title like that and it bothers me as it's not really "everything", it's just github-actions.