### PR TITLE
Fix RoomUpdateError roomId argument typo

### DIFF
--- a/src/ProtectedRoomsSet.ts
+++ b/src/ProtectedRoomsSet.ts
@@ -466,7 +466,7 @@ export class ProtectedRoomsSet {
         errors: IRoomUpdateError[],
         renderOptions: { title?: string, noErrorsText?: string }
     ): Promise<void> {
-        printActionResult(this.client, this.managementRoomId, errors, renderOptions);
+        await printActionResult(this.client, this.managementRoomId, errors, renderOptions);
     }
 
     public async unbanUser(user: string): Promise<IRoomUpdateError[]> {

--- a/src/models/RoomUpdateError.tsx
+++ b/src/models/RoomUpdateError.tsx
@@ -48,9 +48,7 @@ export class PermissionError extends CommandError implements IRoomUpdateError  {
 }
 
 export class RoomUpdateException extends CommandException implements IRoomUpdateError {
-    roomId: string;
-
-    constructor(public readonly: string, ...args: ConstructorParameters<typeof CommandException>) {
+    constructor(public readonly roomId: string, ...args: ConstructorParameters<typeof CommandException>) {
         super(...args);
     }
 


### PR DESCRIPTION
We were clearly in the process of deleting the
member decleration to just have the decleration be in the constructor.

When we were distracted, leaving a property named `readonly`, which shouldn't be possible imo, need to add some rule for that prompto.