### PR TITLE
Try to reduce usage of `any` in the codebase

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -44,6 +44,7 @@ module.exports = {
         "no-trailing-spaces": "error",
         "no-unused-labels": "error",
         "no-var": "error",
-        "radix": "error"
+        "radix": "error",
+        "@typescript-eslint/no-explicit-any": ["error"]
     }
 };

--- a/src/ManagementRoomOutput.ts
+++ b/src/ManagementRoomOutput.ts
@@ -107,7 +107,7 @@ export default class ManagementRoomOutput {
      * @param additionalRoomIds The roomIds in the message that we want to be replaced by room pills.
      * @param isRecursive Whether logMessage is being called from logMessage.
      */
-    public async logMessage(level: LogLevel, module: string, message: string | any, additionalRoomIds: string[] | string | null = null, isRecursive = false): Promise<any> {
+    public async logMessage(level: LogLevel, module: string, message: string, additionalRoomIds: string[] | string | null = null, isRecursive = false): Promise<void> {
         if (level === LogLevel.ERROR) {
             Sentry.captureMessage(`${module}: ${message}`, 'error');
         }

--- a/src/MatrixEmitter.ts
+++ b/src/MatrixEmitter.ts
@@ -36,23 +36,23 @@ import { MatrixClient } from "matrix-bot-sdk";
  * when we're in appservice mode.
  */
 export declare interface MatrixEmitter extends EventEmitter {
-    on(event: 'room.event', listener: (roomId: string, mxEvent: any) => void ): this
-    emit(event: 'room.event', roomId: string, mxEvent: any): boolean
+    on(event: 'room.event', listener: (roomId: string, mxEvent: /* eslint-disable @typescript-eslint/no-explicit-any -- These are due to matrix-bot-sdk */any/* eslint-enable @typescript-eslint/no-explicit-any */) => void): this
+    emit(event: 'room.event', roomId: string, mxEvent: /* eslint-disable @typescript-eslint/no-explicit-any -- These are due to matrix-bot-sdk */any/* eslint-enable @typescript-eslint/no-explicit-any */): boolean
 
-    on(event: 'room.message', listener: (roomId: string, mxEvent: any) => void ): this
-    emit(event: 'room.message', roomId: string, mxEvent: any): boolean
+    on(event: 'room.message', listener: (roomId: string, mxEvent: /* eslint-disable @typescript-eslint/no-explicit-any -- These are due to matrix-bot-sdk */any/* eslint-enable @typescript-eslint/no-explicit-any */) => void): this
+    emit(event: 'room.message', roomId: string, mxEvent: /* eslint-disable @typescript-eslint/no-explicit-any -- These are due to matrix-bot-sdk */any/* eslint-enable @typescript-eslint/no-explicit-any */): boolean
 
-    on(event: 'room.invite', listener: (roomId: string, mxEvent: any) => void ): this
-    emit(event: 'room.invite', roomId: string, mxEvent: any): boolean
+    on(event: 'room.invite', listener: (roomId: string, mxEvent: /* eslint-disable @typescript-eslint/no-explicit-any -- These are due to matrix-bot-sdk */any/* eslint-enable @typescript-eslint/no-explicit-any */) => void): this
+    emit(event: 'room.invite', roomId: string, mxEvent: /* eslint-disable @typescript-eslint/no-explicit-any -- These are due to matrix-bot-sdk */any/* eslint-enable @typescript-eslint/no-explicit-any */): boolean
 
-    on(event: 'room.join', listener: (roomId: string, mxEvent: any) => void ): this
-    emit(event: 'room.join', roomId: string, mxEvent: any): boolean
+    on(event: 'room.join', listener: (roomId: string, mxEvent: /* eslint-disable @typescript-eslint/no-explicit-any -- These are due to matrix-bot-sdk */any/* eslint-enable @typescript-eslint/no-explicit-any */) => void): this
+    emit(event: 'room.join', roomId: string, mxEvent: /* eslint-disable @typescript-eslint/no-explicit-any -- These are due to matrix-bot-sdk */any/* eslint-enable @typescript-eslint/no-explicit-any */): boolean
 
-    on(event: 'room.leave', listener: (roomId: string, mxEvent: any) => void ): this
-    emit(event: 'room.leave', roomId: string, mxEvent: any): boolean
+    on(event: 'room.leave', listener: (roomId: string, mxEvent: /* eslint-disable @typescript-eslint/no-explicit-any -- These are due to matrix-bot-sdk */any/* eslint-enable @typescript-eslint/no-explicit-any */) => void): this
+    emit(event: 'room.leave', roomId: string, mxEvent: /* eslint-disable @typescript-eslint/no-explicit-any -- These are due to matrix-bot-sdk */any/* eslint-enable @typescript-eslint/no-explicit-any */): boolean
 
-    on(event: 'room.archived', listener: (roomId: string, mxEvent: any) => void ): this
-    emit(event: 'room.archived', roomId: string, mxEvent: any): boolean
+    on(event: 'room.archived', listener: (roomId: string, mxEvent: /* eslint-disable @typescript-eslint/no-explicit-any -- These are due to matrix-bot-sdk */any/* eslint-enable @typescript-eslint/no-explicit-any */) => void): this
+    emit(event: 'room.archived', roomId: string, mxEvent: /* eslint-disable @typescript-eslint/no-explicit-any -- These are due to matrix-bot-sdk */any/* eslint-enable @typescript-eslint/no-explicit-any */): boolean
 
     start(): Promise<void>;
     stop(): void;

--- a/src/ProtectedRoomsSet.ts
+++ b/src/ProtectedRoomsSet.ts
@@ -152,7 +152,7 @@ export class ProtectedRoomsSet {
         return this.automaticRedactionReasons;
     }
 
-    public getProtectedRooms () {
+    public getProtectedRooms() {
         return [...this.protectedRooms.keys()]
     }
 
@@ -193,7 +193,7 @@ export class ProtectedRoomsSet {
         return this.protectedRoomActivityTracker.protectedRoomsByActivity();
     }
 
-    public async handleEvent(roomId: string, event: any) {
+    public async handleEvent(roomId: string, event: /* eslint-disable @typescript-eslint/no-explicit-any -- any is used due to matrix-bot-sdk */any/* eslint-enable @typescript-eslint/no-explicit-any */) {
         if (event['sender'] === this.clientUserId) {
             throw new TypeError("`ProtectedRooms::handleEvent` should not be used to inform about events sent by mjolnir.");
         }
@@ -204,7 +204,7 @@ export class ProtectedRoomsSet {
         if (event['type'] === 'm.room.power_levels' && event['state_key'] === '') {
             await this.managementRoomOutput.logMessage(LogLevel.DEBUG, "Mjolnir", `Power levels changed in ${roomId} - checking permissions...`, roomId);
             const errors = await this.protectionManager.verifyPermissionsIn(roomId);
-            await this.printActionResult(errors, { title: "There were errors verifying permissions.", noErrorsText: "All permissions look OK."});
+            await this.printActionResult(errors, { title: "There were errors verifying permissions.", noErrorsText: "All permissions look OK." });
             return;
         } else if (event['type'] === "m.room.member") {
             // The reason we have to apply bans on each member change is because
@@ -358,7 +358,7 @@ export class ProtectedRoomsSet {
         // We can only ban people who are not already banned, and who match the rules.
         const errors: IRoomUpdateError[] = [];
 
-        const addErrorToReport = (roomId: string, e: any) => {
+        const addErrorToReport = (roomId: string, e: /* eslint-disable @typescript-eslint/no-explicit-any -- any is used due to matrix-bot-sdk */any/* eslint-enable @typescript-eslint/no-explicit-any */) => {
             const message = e.message || (e.body ? e.body.error : '<no message>');
             errors.push(new RoomUpdateException(
                 roomId,

--- a/src/RoomMembers.ts
+++ b/src/RoomMembers.ts
@@ -226,7 +226,7 @@ export class RoomMemberManager {
     /**
      * Record join/leave events.
      */
-    public async handleEvent(roomId: string, event: any, now?: Date) {
+    public async handleEvent(roomId: string, event: /* eslint-disable @typescript-eslint/no-explicit-any -- any is used due to matrix-bot-sdk */any/* eslint-enable @typescript-eslint/no-explicit-any */, now?: Date) {
         if (event['type'] !== 'm.room.member') {
             // Not a join/leave event.
             return;

--- a/src/commands/SinceCommand.ts
+++ b/src/commands/SinceCommand.ts
@@ -213,7 +213,8 @@ async function execSinceCommandAux(destinationRoomId: string, event: any, mjolni
             } else if (maybeRoom.startsWith("#") || maybeRoom.startsWith("!")) {
                 const roomId = await mjolnir.client.resolveRoom(maybeRoom);
                 if (!protectedRooms.has(roomId)) {
-                    return mjolnir.managementRoomOutput.logMessage(LogLevel.WARN, "SinceCommand", `This room is not protected: ${htmlEscape(roomId)}.`);
+                    mjolnir.managementRoomOutput.logMessage(LogLevel.WARN, "SinceCommand", `This room is not protected: ${htmlEscape(roomId)}.`);
+                    return { error: `This room is not protected: ${htmlEscape(roomId)}.` };
                 }
                 rooms.add(roomId);
                 continue;

--- a/src/config.ts
+++ b/src/config.ts
@@ -225,7 +225,7 @@ export function getDefaultConfig(): IConfig {
  * @param argv An arguments vector sourced from `process.argv`.
  * @returns The path if one was provided or undefined.
  */
-function configPathFromArguments(argv: string[]): undefined|string {
+function configPathFromArguments(argv: string[]): undefined | string {
     const configOptionIndex = argv.findIndex(arg => arg === "--draupnir-config");
     if (configOptionIndex > 0) {
         const configOptionPath = argv.at(configOptionIndex + 1);
@@ -277,7 +277,7 @@ export function getProvisionedMjolnirConfig(managementRoomId: string): IConfig {
     }
     const config = Config.util.extendDeep(
         getDefaultConfig(),
-        allowedKeys.reduce((existingConfig: any, key: string) => {
+        allowedKeys.reduce((existingConfig: /* eslint-disable @typescript-eslint/no-explicit-any -- any is used due to how reduce works. We deal with unknown content before this is finished. */any/* eslint-enable @typescript-eslint/no-explicit-any */, key: string) => {
             return { ...existingConfig, [key]: configTemplate[key as keyof IConfig] }
         }, {})
     );


### PR DESCRIPTION
This also makes the usage of `any` be a linter error by default. In most cases, we likely don't want `any`. Most usages that currently exist seem to be from `matrix-bot-sdk`. Some are from nodejs itself.