### PR TITLE
Add support for bot-sdk crypto as an experimental flag

### DIFF
--- a/config/default.yaml
+++ b/config/default.yaml
@@ -28,6 +28,13 @@ pantalaimon:
   # After successfully logging in once, this will be ignored, so this value can be blanked after first startup.
   password: your_password
 
+# Experimental usage of the matrix-bot-sdk rust crypto.
+# This can not be used with Pantalaimon.
+# Make sure to setup the bot as if you are not using pantalaimon for this.
+#
+# Warning: At this time this is not considered production safe.
+experimentalRustCrypto: false
+
 # The path Draupnir will store its state/data in, leave default ("/data/storage") when using containers.
 dataPath: "/data/storage"
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -129,6 +129,9 @@ export interface IConfig {
             enabled: boolean;
         }
     }
+    // Experimental usage of the matrix-bot-sdk rust crypto.
+    // This can not be used with Pantalaimon.
+    experimentalRustCrypto: boolean;
 
     /**
      * Config options only set at runtime. Try to avoid using the objects
@@ -210,6 +213,7 @@ const defaultConfig: IConfig = {
             enabled: false,
         },
     },
+    experimentalRustCrypto: false,
 
     // Needed to make the interface happy.
     RUNTIME: {
@@ -225,7 +229,7 @@ export function getDefaultConfig(): IConfig {
  * @param argv An arguments vector sourced from `process.argv`.
  * @returns The path if one was provided or undefined.
  */
-function configPathFromArguments(argv: string[]): undefined|string {
+function configPathFromArguments(argv: string[]): undefined | string {
     const configOptionIndex = argv.findIndex(arg => arg === "--draupnir-config");
     if (configOptionIndex > 0) {
         const configOptionPath = argv.at(configOptionIndex + 1);

--- a/src/index.ts
+++ b/src/index.ts
@@ -35,7 +35,8 @@ import {
     MatrixClient,
     PantalaimonClient,
     RichConsoleLogger,
-    SimpleFsStorageProvider
+    SimpleFsStorageProvider,
+    RustSdkCryptoStorageProvider
 } from "matrix-bot-sdk";
 
 import { read as configRead } from "./config";
@@ -69,9 +70,17 @@ import { initializeSentry, patchMatrixClient } from "./utils";
         const storage = new SimpleFsStorageProvider(path.join(storagePath, "bot.json"));
 
         let client: MatrixClient;
-        if (config.pantalaimon.use) {
+        if (config.pantalaimon.use && !config.experimentalRustCrypto) {
             const pantalaimon = new PantalaimonClient(config.homeserverUrl, storage);
             client = await pantalaimon.createClientWithCredentials(config.pantalaimon.username, config.pantalaimon.password);
+        } else if (config.experimentalRustCrypto) {
+            if (config.pantalaimon.use) {
+                console.warn("You have a pantalaimon config activated and experimentalRustCrypto. Make sure the accessToken is set and pantalaimon is disabled!");
+            }
+            // 0 means sqlite. It comes from "@matrix-org/matrix-sdk-crypto-nodejs" and is ensured to be 0 by https://github.com/matrix-org/matrix-rust-sdk-crypto-nodejs/blob/8cfee331a7fbfb00625bd3b86a78686a0f954534/tests/machine.test.js#L27-L31
+            const cryptoStorage = new RustSdkCryptoStorageProvider(path.join(storagePath, "crypto"), 0);
+
+            client = new MatrixClient(config.homeserverUrl, config.accessToken, storage, cryptoStorage);
         } else {
             client = new MatrixClient(config.homeserverUrl, config.accessToken, storage);
         }

--- a/src/index.ts
+++ b/src/index.ts
@@ -38,7 +38,7 @@ import {
     SimpleFsStorageProvider,
     RustSdkCryptoStorageProvider
 } from "matrix-bot-sdk";
-
+import { StoreType } from "@matrix-org/matrix-sdk-crypto-nodejs";
 import { read as configRead } from "./config";
 import { Mjolnir } from "./Mjolnir";
 import { initializeSentry, patchMatrixClient } from "./utils";
@@ -78,7 +78,7 @@ import { initializeSentry, patchMatrixClient } from "./utils";
                 console.warn("You have a pantalaimon config activated and experimentalRustCrypto. Make sure the accessToken is set and pantalaimon is disabled!");
             }
             // 0 means sqlite. It comes from "@matrix-org/matrix-sdk-crypto-nodejs" and is ensured to be 0 by https://github.com/matrix-org/matrix-rust-sdk-crypto-nodejs/blob/8cfee331a7fbfb00625bd3b86a78686a0f954534/tests/machine.test.js#L27-L31
-            const cryptoStorage = new RustSdkCryptoStorageProvider(path.join(storagePath, "crypto"), 0);
+            const cryptoStorage = new RustSdkCryptoStorageProvider(path.join(storagePath, "crypto"), StoreType.Sqlite);
 
             client = new MatrixClient(config.homeserverUrl, config.accessToken, storage, cryptoStorage);
         } else {

--- a/src/index.ts
+++ b/src/index.ts
@@ -77,7 +77,6 @@ import { initializeSentry, patchMatrixClient } from "./utils";
             if (config.pantalaimon.use) {
                 throw Error("You have a pantalaimon config activated and experimentalRustCrypto. Make sure the accessToken is set and pantalaimon is disabled!");
             }
-            // 0 means sqlite. It comes from "@matrix-org/matrix-sdk-crypto-nodejs" and is ensured to be 0 by https://github.com/matrix-org/matrix-rust-sdk-crypto-nodejs/blob/8cfee331a7fbfb00625bd3b86a78686a0f954534/tests/machine.test.js#L27-L31
             const cryptoStorage = new RustSdkCryptoStorageProvider(path.join(storagePath, "crypto"), StoreType.Sqlite);
 
             client = new MatrixClient(config.homeserverUrl, config.accessToken, storage, cryptoStorage);

--- a/src/index.ts
+++ b/src/index.ts
@@ -75,7 +75,7 @@ import { initializeSentry, patchMatrixClient } from "./utils";
             client = await pantalaimon.createClientWithCredentials(config.pantalaimon.username, config.pantalaimon.password);
         } else if (config.experimentalRustCrypto) {
             if (config.pantalaimon.use) {
-                console.warn("You have a pantalaimon config activated and experimentalRustCrypto. Make sure the accessToken is set and pantalaimon is disabled!");
+                throw Error("You have a pantalaimon config activated and experimentalRustCrypto. Make sure the accessToken is set and pantalaimon is disabled!");
             }
             // 0 means sqlite. It comes from "@matrix-org/matrix-sdk-crypto-nodejs" and is ensured to be 0 by https://github.com/matrix-org/matrix-rust-sdk-crypto-nodejs/blob/8cfee331a7fbfb00625bd3b86a78686a0f954534/tests/machine.test.js#L27-L31
             const cryptoStorage = new RustSdkCryptoStorageProvider(path.join(storagePath, "crypto"), StoreType.Sqlite);


### PR DESCRIPTION
Adds `experimentalRustCrypto` as a boolean flag to the config. As this obviously is mutually exclusive with pantalaimon it does disable pantalaimon if used. It also issues a warning if `config.pantalaimon.use` is also true. Since that likely is invalid, config. However, as long as `accessToken` is also set, it will work. Otherwise, it fails regardless trying to log in.