### PR TITLE
Initial MSC1929 Implementation

### DIFF
--- a/mx-tester.yml
+++ b/mx-tester.yml
@@ -6,7 +6,7 @@ up:
     # Wait until postgresql is ready
     - until psql postgres://mjolnir-tester:mjolnir-test@127.0.0.1:8083/mjolnir-test-db -c ""; do echo "Waiting for psql..."; sleep 1s; done
     # Launch the reverse proxy, listening for connections *only* on the local host.
-    - docker run --rm --network host --name mjolnir-test-reverse-proxy -p 127.0.0.1:8084:8084 -p 127.0.0.1:8085:8085 -p 127.0.0.1:8086:8086 -p 127.0.0.1:8081:8081 -v $MX_TEST_CWD/test/nginx.conf:/etc/nginx/nginx.conf:ro -d nginx
+    - docker run --rm --network host --name mjolnir-test-reverse-proxy -v $MX_TEST_CWD/test/nginx.conf:/etc/nginx/nginx.conf:ro -d nginx
     - yarn install
     - npx ts-node src/appservice/cli.ts -r -u "http://host.docker.internal:9000"
     - cp mjolnir-registration.yaml $MX_TEST_SYNAPSE_DIR/data/

--- a/mx-tester.yml
+++ b/mx-tester.yml
@@ -6,7 +6,7 @@ up:
     # Wait until postgresql is ready
     - until psql postgres://mjolnir-tester:mjolnir-test@127.0.0.1:8083/mjolnir-test-db -c ""; do echo "Waiting for psql..."; sleep 1s; done
     # Launch the reverse proxy, listening for connections *only* on the local host.
-    - docker run --rm --network host --name mjolnir-test-reverse-proxy -p 127.0.0.1:8081:80 -v $MX_TEST_CWD/test/nginx.conf:/etc/nginx/nginx.conf:ro -d nginx
+    - docker run --rm --network host --name mjolnir-test-reverse-proxy -p 127.0.0.1:8084:8084 -p 127.0.0.1:8085:8085 -p 127.0.0.1:8086:8086 -p 127.0.0.1:8081:8081 -v $MX_TEST_CWD/test/nginx.conf:/etc/nginx/nginx.conf:ro -d nginx
     - yarn install
     - npx ts-node src/appservice/cli.ts -r -u "http://host.docker.internal:9000"
     - cp mjolnir-registration.yaml $MX_TEST_SYNAPSE_DIR/data/

--- a/mx-tester.yml
+++ b/mx-tester.yml
@@ -6,7 +6,7 @@ up:
     # Wait until postgresql is ready
     - until psql postgres://mjolnir-tester:mjolnir-test@127.0.0.1:8083/mjolnir-test-db -c ""; do echo "Waiting for psql..."; sleep 1s; done
     # Launch the reverse proxy, listening for connections *only* on the local host.
-    - docker run --rm --network host --name mjolnir-test-reverse-proxy -v $MX_TEST_CWD/test/nginx.conf:/etc/nginx/nginx.conf:ro -d nginx
+    - docker run --rm --network host --name mjolnir-test-reverse-proxy -p 127.0.0.1:8084:8084 -p 127.0.0.1:8085:8085 -p 127.0.0.1:8086:8086 -p 127.0.0.1:8081:80 -v $MX_TEST_CWD/test/nginx.conf:/etc/nginx/nginx.conf:ro -d nginx
     - yarn install
     - npx ts-node src/appservice/cli.ts -r -u "http://host.docker.internal:9000"
     - cp mjolnir-registration.yaml $MX_TEST_SYNAPSE_DIR/data/

--- a/mx-tester.yml
+++ b/mx-tester.yml
@@ -6,7 +6,7 @@ up:
     # Wait until postgresql is ready
     - until psql postgres://mjolnir-tester:mjolnir-test@127.0.0.1:8083/mjolnir-test-db -c ""; do echo "Waiting for psql..."; sleep 1s; done
     # Launch the reverse proxy, listening for connections *only* on the local host.
-    - docker run --rm --network host --name mjolnir-test-reverse-proxy -p 127.0.0.1:8084:8084 -p 127.0.0.1:8085:8085 -p 127.0.0.1:8086:8086 -p 127.0.0.1:8081:80 -v $MX_TEST_CWD/test/nginx.conf:/etc/nginx/nginx.conf:ro -d nginx
+    - docker run --rm --network host --name mjolnir-test-reverse-proxy -v $MX_TEST_CWD/test/nginx.conf:/etc/nginx/nginx.conf:ro -d nginx
     - yarn install
     - npx ts-node src/appservice/cli.ts -r -u "http://host.docker.internal:9000"
     - cp mjolnir-registration.yaml $MX_TEST_SYNAPSE_DIR/data/

--- a/src/commands/CommandHandler.ts
+++ b/src/commands/CommandHandler.ts
@@ -73,6 +73,7 @@ import "./Rules";
 import "./WatchUnwatchCommand";
 import "./Help";
 import "./SetDisplayNameCommand";
+import "./QueryAdminDetails";
 
 export const COMMAND_PREFIX = "!mjolnir";
 

--- a/src/commands/QueryAdminDetails.tsx
+++ b/src/commands/QueryAdminDetails.tsx
@@ -39,8 +39,6 @@ async function queryAdminDetails(
         // Doing some cleanup on the url
         if (!entity.startsWith("https://") && !entity.startsWith("http://")) {
             domain = `https://${entity}`;
-        } else if (entity.startsWith("http://")) {
-            domain = entity.replace("http://", "https://");
         } else {
             domain = entity;
         }

--- a/src/commands/QueryAdminDetails.tsx
+++ b/src/commands/QueryAdminDetails.tsx
@@ -15,7 +15,7 @@ export type MatrixHomeserver = string;
 makePresentationType({
     name: "MatrixHomeserver",
     // This is a very very crude way to detect a url.
-    validator: simpleTypeValidator("MatrixHomeserver", (readItem: ReadItem) => (readItem instanceof String) && (!readItem.includes('#') || !readItem.includes('!')) && !readItem.includes('.'))
+    validator: simpleTypeValidator("MatrixHomeserver", (readItem: ReadItem) => (readItem instanceof String) && (!readItem.includes('#') || !readItem.includes('!')))
 })
 
 interface SupportJson {

--- a/src/commands/QueryAdminDetails.tsx
+++ b/src/commands/QueryAdminDetails.tsx
@@ -2,14 +2,21 @@ import { Permalinks, UserID, getRequestFn } from "matrix-bot-sdk";
 import { MjolnirContext } from "./CommandHandler";
 import { CommandError, CommandResult } from "./interface-manager/Validation";
 import { defineInterfaceCommand, findTableCommand } from "./interface-manager/InterfaceCommand";
-import { findPresentationType, parameters, ParsedKeywords, union } from "./interface-manager/ParameterParsing";
+import { findPresentationType, makePresentationType, parameters, ParsedKeywords, simpleTypeValidator, union } from "./interface-manager/ParameterParsing";
 import "./interface-manager/MatrixPresentations";
 import { JSXFactory } from "./interface-manager/JSXFactory";
 import { defineMatrixInterfaceAdaptor } from "./interface-manager/MatrixInterfaceAdaptor";
 import { renderMatrixAndSend } from "./interface-manager/DeadDocumentMatrix";
 import { DocumentNode } from "./interface-manager/DeadDocument";
+import { ReadItem } from "./interface-manager/CommandReader";
 
 export type MatrixHomeserver = string;
+
+makePresentationType({
+    name: "MatrixHomeserver",
+    // This is a very very crude way to detect a url.
+    validator: simpleTypeValidator("MatrixHomeserver", (readItem: ReadItem) => (readItem instanceof String) && (!readItem.includes('#') || !readItem.includes('!')) && !readItem.includes('.'))
+})
 
 interface SupportJson {
     contacts?: {

--- a/src/commands/QueryAdminDetails.tsx
+++ b/src/commands/QueryAdminDetails.tsx
@@ -87,26 +87,26 @@ defineInterfaceCommand({
 function renderSupportJson([entity, support_json]: [UserID | MatrixHomeserver | string, SupportJson],): DocumentNode {
     if (!support_json.support_page) {
         return <root>
-            <b>Support infos for ({entity}):</b>
+            <b>Support infos for ({entity}):</b><br />
             <ul>
-                {support_json.contacts!.map(r => <li><b>{r.role}</b> - {r.matrix_id ? <a href={Permalinks.forUser(r.matrix_id)}>{r.matrix_id}</a> : <a href="mailto:{r.email_address}">{r.email_address}</a>}</li>)}
+                {support_json.contacts!.map(r => <li><b>{r.role}</b> - {r.matrix_id ? <a href={Permalinks.forUser(r.matrix_id)}>{r.matrix_id}</a> : <a href="mailto:{r.email_address}">{r.email_address}</a>}<br /></li>)}
             </ul>
         </root>
     } else if (!support_json.contacts) {
         return <root>
-            <b>Support Page for ({entity}):</b>
+            <b>Support Page for ({entity}):</b><br />
             <p>
                 Support Page: {support_json.support_page}
             </p>
         </root>
     } else {
         return <root>
-            <b>Support info for ({entity}):</b>
+            <b>Support info for ({entity}):</b><br />
             <p>
                 Support Page: {support_json.support_page}
-            </p>
+            </p><br />
             <ul>
-                {support_json.contacts!.map(r => <li><b>{r.role}</b> - {r.matrix_id ? <a href={Permalinks.forUser(r.matrix_id)}>{r.matrix_id}</a> : <a href="mailto:{r.email_address}">{r.email_address}</a>}</li>)}
+                {support_json.contacts!.map(r => <li><b>{r.role}</b> - {r.matrix_id ? <a href={Permalinks.forUser(r.matrix_id)}>{r.matrix_id}</a> : <a href="mailto:{r.email_address}">{r.email_address}</a>}<br /></li>)}
             </ul>
         </root>
     }

--- a/src/commands/QueryAdminDetails.tsx
+++ b/src/commands/QueryAdminDetails.tsx
@@ -47,13 +47,13 @@ async function queryAdminDetails(
 
     try {
         const resp: SupportJson = await new Promise((resolve, reject) => {
-            getRequestFn()(`${domain}/.well-known/matrix/support`, (error: any, response: any, resBody: string) => {
+            getRequestFn()(`${domain}/.well-known/matrix/support`, (error: any, response: any, resBody: unknown) => {
                 if (error) {
                     reject(new CommandError(`The request failed with an error: ${error}.`));
                 } else if (response.statusCode !== 200) {
                     reject(new CommandError(`The server didn't reply with a valid response code: ${response.statusCode}.`));
-                } else if (resBody !== null && (resBody.includes('contacts') || resBody.includes('support_page'))) {
-                    resolve(JSON.parse(resBody) as SupportJson)
+                } else if (typeof resBody === 'object' && resBody !== null && ('contacts' in resBody || 'support_page' in resBody)) {
+                    resolve(resBody as SupportJson)
                 } else if (resBody === null) {
                     reject(new CommandError(`The response was empty.`));
                 } else {

--- a/src/commands/QueryAdminDetails.tsx
+++ b/src/commands/QueryAdminDetails.tsx
@@ -1,0 +1,111 @@
+import { Permalinks, UserID, getRequestFn } from "matrix-bot-sdk";
+import { MjolnirContext } from "./CommandHandler";
+import { CommandError, CommandResult } from "./interface-manager/Validation";
+import { defineInterfaceCommand, findTableCommand } from "./interface-manager/InterfaceCommand";
+import { findPresentationType, parameters, ParsedKeywords, union } from "./interface-manager/ParameterParsing";
+import "./interface-manager/MatrixPresentations";
+import { JSXFactory } from "./interface-manager/JSXFactory";
+import { defineMatrixInterfaceAdaptor } from "./interface-manager/MatrixInterfaceAdaptor";
+import { renderMatrixAndSend } from "./interface-manager/DeadDocumentMatrix";
+import { DocumentNode } from "./interface-manager/DeadDocument";
+
+export type MatrixHomeserver = string;
+
+interface SupportJson {
+    contacts?: {
+        matrix_id?: string,
+        email_address?: string;
+        role: "admin" | "security";
+    }[],
+    support_page?: string;
+}
+
+async function queryAdminDetails(
+    this: MjolnirContext,
+    _keywords: ParsedKeywords,
+    entity: UserID | MatrixHomeserver | string
+): Promise<CommandResult<[UserID | MatrixHomeserver | string, SupportJson], CommandError>> {
+    let domain: string;
+    if (entity instanceof UserID) {
+        domain = `https://${entity.domain}`;
+    } else {
+        // Doing some cleanup on the url
+        if (!entity.startsWith("https://") && !entity.startsWith("http://")) {
+            domain = `https://${entity}`;
+        } else if (entity.startsWith("http://")) {
+            domain = entity.replace("http://", "https://");
+        } else {
+            domain = entity;
+        }
+    }
+
+
+    const resp: SupportJson = await new Promise((resolve, reject) => {
+        getRequestFn()(`${domain}/.well-known/matrix/support`, (error: any, response: any, resBody: unknown) => {
+            if (error || response.statusCode !== 200) {
+                reject(error);
+            } else if (typeof resBody === 'object' && resBody !== null && ('contacts' in resBody || 'support_page' in resBody)) {
+                resolve(resBody as SupportJson)
+            } else {
+                reject(new TypeError(`Don't know what to do with response body ${JSON.stringify(resBody)}. Assuming its not a json`));
+            }
+        });
+    });
+
+    return CommandResult.Ok([entity, resp]);
+}
+
+defineInterfaceCommand({
+    designator: ["queryAdmin"],
+    table: "mjolnir",
+    parameters: parameters([
+        {
+            name: "entity",
+            acceptor: union(
+                findPresentationType("UserID"),
+                findPresentationType("MatrixHomeserver"),
+                findPresentationType("string")
+            )
+        }
+    ]),
+    command: queryAdminDetails,
+    summary: "Queries the admin of the Homeserver or user using MSC1929 if available",
+})
+
+function renderSupportJson([entity, support_json]: [UserID | MatrixHomeserver | string, SupportJson],): DocumentNode {
+    if (!support_json.support_page) {
+        return <root>
+            <b>Support infos for ({entity}):</b>
+            <ul>
+                {support_json.contacts!.map(r => <li><b>{r.role}</b> - {r.matrix_id ? <a href={Permalinks.forUser(r.matrix_id)}>{r.matrix_id}</a> : <a href="mailto:{r.email_address}">{r.email_address}</a>}</li>)}
+            </ul>
+        </root>
+    } else if (!support_json.contacts) {
+        return <root>
+            <b>Support Page for ({entity}):</b>
+            <p>
+                Support Page: {support_json.support_page}
+            </p>
+        </root>
+    } else {
+        return <root>
+            <b>Support info for ({entity}):</b>
+            <p>
+                Support Page: {support_json.support_page}
+            </p>
+            <ul>
+                {support_json.contacts!.map(r => <li><b>{r.role}</b> - {r.matrix_id ? <a href={Permalinks.forUser(r.matrix_id)}>{r.matrix_id}</a> : <a href="mailto:{r.email_address}">{r.email_address}</a>}</li>)}
+            </ul>
+        </root>
+    }
+}
+
+defineMatrixInterfaceAdaptor({
+    interfaceCommand: findTableCommand("mjolnir", "queryAdmin"),
+    renderer: async function (client, commandRoomId, event, result) {
+        await renderMatrixAndSend(
+            renderSupportJson(result.ok),
+            commandRoomId, event, client
+        );
+    }
+})

--- a/test/integration/commands/queryAdminDetailsTest.ts
+++ b/test/integration/commands/queryAdminDetailsTest.ts
@@ -26,7 +26,7 @@ describe("Test: The queryAdmin command", function () {
         const reply_event = await getFirstReply(this.mjolnir.matrixEmitter, this.mjolnir.managementRoomId, async () => {
             return await moderator.sendMessage(this.mjolnir.managementRoomId, { msgtype: 'm.text', body: `!mjolnir query admin http://localhost:7072` });
         });
-        assert.equal(reply_event.content.body, "**Support infos for (http://localhost:7072):**\n\n * **admin** - [@admin:localhost](https://matrix.to/#/@admin:localhost)\n\n", `Draupnir did not parse the json as expected.`);
+        assert.equal(reply_event.content.body, "**Support info for (http://localhost:7072):**\n\n * **admin** - [@admin:localhost](https://matrix.to/#/@admin:localhost)\n\n", `Draupnir did not parse the json as expected.`);
     })
 
     it('Mjölnir can query and display the query results for a partial support_page-only json.', async function () {

--- a/test/integration/commands/queryAdminDetailsTest.ts
+++ b/test/integration/commands/queryAdminDetailsTest.ts
@@ -1,0 +1,89 @@
+import { strict as assert } from "assert";
+
+import { newTestUser } from "../clientHelper";
+import { getMessagesByUserIn } from "../../../src/utils";
+
+describe("Test: The queryAdmin command", function () {
+    // If a test has a timeout while awaitng on a promise then we never get given control back.
+    afterEach(function () { this.moderator?.stop(); });
+
+    it('Mjölnir can query and display the query results for a complete json.', async function () {
+        let moderator = await newTestUser(this.config.homeserverUrl, { name: { contains: "moderator" } });
+        this.moderator = moderator;
+        await moderator.joinRoom(this.config.managementRoom);
+        moderator.sendMessage(this.mjolnir.managementRoomId, { msgtype: 'm.text.', body: `!mjolnir queryAdmin http://localhost:8081` });
+
+
+        const draupnir = this.config.RUNTIME.client!
+        let draupnirUserId = await draupnir.getUserId();
+
+        // Check if draupnir replied
+        await getMessagesByUserIn(moderator, draupnirUserId, this.mjolnir.managementRoomId, 1000, function (events) {
+            events.map(e => {
+                if (e.type === 'm.room.message') {
+                    assert.equal(e.content.body, "", `Draipnir did not parse the json as expected: ${e.content.body}.`)
+                }
+            })
+        });
+    })
+
+    it('Mjölnir can query and display the query results for a partial contacts-only json.', async function () {
+        let moderator = await newTestUser(this.config.homeserverUrl, { name: { contains: "moderator" } });
+        this.moderator = moderator;
+        await moderator.joinRoom(this.config.managementRoom);
+        moderator.sendMessage(this.mjolnir.managementRoomId, { msgtype: 'm.text.', body: `!mjolnir queryAdmin http://localhost:7072` });
+
+
+        const draupnir = this.config.RUNTIME.client!
+        let draupnirUserId = await draupnir.getUserId();
+
+        // Check if draupnir replied
+        await getMessagesByUserIn(moderator, draupnirUserId, this.mjolnir.managementRoomId, 1000, function (events) {
+            events.map(e => {
+                if (e.type === 'm.room.message') {
+                    assert.equal(e.content.body, "", `Draipnir did not parse the json as expected: ${e.content.body}.`)
+                }
+            })
+        });
+    })
+
+    it('Mjölnir can query and display the query results for a partial support_page-only json.', async function () {
+        let moderator = await newTestUser(this.config.homeserverUrl, { name: { contains: "moderator" } });
+        this.moderator = moderator;
+        await moderator.joinRoom(this.config.managementRoom);
+        moderator.sendMessage(this.mjolnir.managementRoomId, { msgtype: 'm.text.', body: `!mjolnir queryAdmin http://localhost:7071` });
+
+
+        const draupnir = this.config.RUNTIME.client!
+        let draupnirUserId = await draupnir.getUserId();
+
+        // Check if draupnir replied
+        await getMessagesByUserIn(moderator, draupnirUserId, this.mjolnir.managementRoomId, 1000, function (events) {
+            events.map(e => {
+                if (e.type === 'm.room.message') {
+                    assert.equal(e.content.body, "", `Draipnir did not parse the json as expected: ${e.content.body}.`)
+                }
+            })
+        });
+    })
+
+    it('Mjölnir can query and display an error for a non well-formed json.', async function () {
+        let moderator = await newTestUser(this.config.homeserverUrl, { name: { contains: "moderator" } });
+        this.moderator = moderator;
+        await moderator.joinRoom(this.config.managementRoom);
+        moderator.sendMessage(this.mjolnir.managementRoomId, { msgtype: 'm.text.', body: `!mjolnir queryAdmin http://localhost:7070` });
+
+
+        const draupnir = this.config.RUNTIME.client!
+        let draupnirUserId = await draupnir.getUserId();
+
+        // Check if draupnir replied
+        await getMessagesByUserIn(moderator, draupnirUserId, this.mjolnir.managementRoomId, 1000, function (events) {
+            events.map(e => {
+                if (e.type === 'm.room.message') {
+                    assert.equal(e.content.body, "", `Draipnir did not parse the json as expected: ${e.content.body}.`)
+                }
+            })
+        });
+    })
+});

--- a/test/integration/commands/queryAdminDetailsTest.ts
+++ b/test/integration/commands/queryAdminDetailsTest.ts
@@ -1,6 +1,7 @@
 import { strict as assert } from "assert";
 
-import { newTestUser, noticeListener } from "../clientHelper";
+import { newTestUser } from "../clientHelper";
+import { getFirstReply } from "./commandUtils";
 
 describe("Test: The queryAdmin command", function () {
     // If a test has a timeout while awaitng on a promise then we never get given control back.
@@ -11,19 +12,10 @@ describe("Test: The queryAdmin command", function () {
         this.moderator = moderator;
         await moderator.joinRoom(this.config.managementRoom);
 
-        // listener for getting the event reply
-        const reply = new Promise<any>((resolve, reject) => {
-            moderator.on('room.message', noticeListener(this.mjolnir.managementRoomId, (event) => {
-                resolve(event);
-            }))
+        const reply_event = await getFirstReply(this.mjolnir.matrixEmitter, this.mjolnir.managementRoomId, async () => {
+            return await moderator.sendMessage(this.mjolnir.managementRoomId, { msgtype: 'm.text', body: `!mjolnir queryAdmin http://localhost:8081` });
         });
-
-        await moderator.sendMessage(this.mjolnir.managementRoomId, { msgtype: 'm.text.', body: `!mjolnir queryAdmin http://localhost:8081` });
-
-
-        const reply_event = await reply;
-
-        assert.equal(reply_event.content.body, "", `Draupnir did not parse the json as expected: ${reply_event.content.body}.`)
+        assert.equal(reply_event.content.body, "", `Draupnir did not parse the json as expected: ${reply_event.content.body}.`);
     })
 
     it('Mjölnir can query and display the query results for a partial contacts-only json.', async function () {
@@ -31,18 +23,10 @@ describe("Test: The queryAdmin command", function () {
         this.moderator = moderator;
         await moderator.joinRoom(this.config.managementRoom);
 
-        // listener for getting the event reply
-        const reply = new Promise<any>((resolve, reject) => {
-            moderator.on('room.message', noticeListener(this.mjolnir.managementRoomId, (event) => {
-                resolve(event);
-            }))
+        const reply_event = await getFirstReply(this.mjolnir.matrixEmitter, this.mjolnir.managementRoomId, async () => {
+            return await moderator.sendMessage(this.mjolnir.managementRoomId, { msgtype: 'm.text', body: `!mjolnir queryAdmin http://localhost:7072` });
         });
-
-        await moderator.sendMessage(this.mjolnir.managementRoomId, { msgtype: 'm.text.', body: `!mjolnir queryAdmin http://localhost:7072` });
-
-        const reply_event = await reply;
-
-        assert.equal(reply_event.content.body, "", `Draupnir did not parse the json as expected: ${reply_event.content.body}.`)
+        assert.equal(reply_event.content.body, "", `Draupnir did not parse the json as expected: ${reply_event.content.body}.`);
     })
 
     it('Mjölnir can query and display the query results for a partial support_page-only json.', async function () {
@@ -50,18 +34,10 @@ describe("Test: The queryAdmin command", function () {
         this.moderator = moderator;
         await moderator.joinRoom(this.config.managementRoom);
 
-        // listener for getting the event reply
-        const reply = new Promise<any>((resolve, reject) => {
-            moderator.on('room.message', noticeListener(this.mjolnir.managementRoomId, (event) => {
-                resolve(event);
-            }))
+        const reply_event = await getFirstReply(this.mjolnir.matrixEmitter, this.mjolnir.managementRoomId, async () => {
+            return await moderator.sendMessage(this.mjolnir.managementRoomId, { msgtype: 'm.text', body: `!mjolnir queryAdmin http://localhost:7071` });
         });
-
-        await moderator.sendMessage(this.mjolnir.managementRoomId, { msgtype: 'm.text.', body: `!mjolnir queryAdmin http://localhost:7071` });
-
-        const reply_event = await reply;
-
-        assert.equal(reply_event.content.body, "", `Draupnir did not parse the json as expected: ${reply_event.content.body}.`)
+        assert.equal(reply_event.content.body, "", `Draupnir did not parse the json as expected: ${reply_event.content.body}.`);
     })
 
     it('Mjölnir can query and display an error for a non well-formed json.', async function () {
@@ -69,17 +45,9 @@ describe("Test: The queryAdmin command", function () {
         this.moderator = moderator;
         await moderator.joinRoom(this.config.managementRoom);
 
-        // listener for getting the event reply
-        const reply = new Promise<any>((resolve, reject) => {
-            moderator.on('room.message', noticeListener(this.mjolnir.managementRoomId, (event) => {
-                resolve(event);
-            }))
+        const reply_event = await getFirstReply(this.mjolnir.matrixEmitter, this.mjolnir.managementRoomId, async () => {
+            return await moderator.sendMessage(this.mjolnir.managementRoomId, { msgtype: 'm.text', body: `!mjolnir queryAdmin http://localhost:7070` });
         });
-
-        moderator.sendMessage(this.mjolnir.managementRoomId, { msgtype: 'm.text.', body: `!mjolnir queryAdmin http://localhost:7070` });
-
-        const reply_event = await reply;
-
-        assert.equal(reply_event.content.body, "", `Draupnir did not parse the json as expected: ${reply_event.content.body}.`)
+        assert.equal(reply_event.content.body, "", `Draupnir did not parse the json as expected: ${reply_event.content.body}.`);
     })
 });

--- a/test/integration/commands/queryAdminDetailsTest.ts
+++ b/test/integration/commands/queryAdminDetailsTest.ts
@@ -21,7 +21,7 @@ describe("Test: The queryAdmin command", function () {
         await getMessagesByUserIn(moderator, draupnirUserId, this.mjolnir.managementRoomId, 1000, function (events) {
             events.map(e => {
                 if (e.type === 'm.room.message') {
-                    assert.equal(e.content.body, "", `Draipnir did not parse the json as expected: ${e.content.body}.`)
+                    assert.equal(e.content.body, "", `Draupnir did not parse the json as expected: ${e.content.body}.`)
                 }
             })
         });
@@ -41,7 +41,7 @@ describe("Test: The queryAdmin command", function () {
         await getMessagesByUserIn(moderator, draupnirUserId, this.mjolnir.managementRoomId, 1000, function (events) {
             events.map(e => {
                 if (e.type === 'm.room.message') {
-                    assert.equal(e.content.body, "", `Draipnir did not parse the json as expected: ${e.content.body}.`)
+                    assert.equal(e.content.body, "", `Draupnir did not parse the json as expected: ${e.content.body}.`)
                 }
             })
         });
@@ -61,7 +61,7 @@ describe("Test: The queryAdmin command", function () {
         await getMessagesByUserIn(moderator, draupnirUserId, this.mjolnir.managementRoomId, 1000, function (events) {
             events.map(e => {
                 if (e.type === 'm.room.message') {
-                    assert.equal(e.content.body, "", `Draipnir did not parse the json as expected: ${e.content.body}.`)
+                    assert.equal(e.content.body, "", `Draupnir did not parse the json as expected: ${e.content.body}.`)
                 }
             })
         });
@@ -81,7 +81,7 @@ describe("Test: The queryAdmin command", function () {
         await getMessagesByUserIn(moderator, draupnirUserId, this.mjolnir.managementRoomId, 1000, function (events) {
             events.map(e => {
                 if (e.type === 'm.room.message') {
-                    assert.equal(e.content.body, "", `Draipnir did not parse the json as expected: ${e.content.body}.`)
+                    assert.equal(e.content.body, "", `Draupnir did not parse the json as expected: ${e.content.body}.`)
                 }
             })
         });

--- a/test/integration/commands/queryAdminDetailsTest.ts
+++ b/test/integration/commands/queryAdminDetailsTest.ts
@@ -15,7 +15,7 @@ describe("Test: The queryAdmin command", function () {
         const reply_event = await getFirstReply(this.mjolnir.matrixEmitter, this.mjolnir.managementRoomId, async () => {
             return await moderator.sendMessage(this.mjolnir.managementRoomId, { msgtype: 'm.text', body: `!mjolnir queryAdmin http://localhost:8081` });
         });
-        assert.equal(reply_event.content.body, "", `Draupnir did not parse the json as expected: ${reply_event.content.body}.`);
+        assert.equal(reply_event.content.body, "**Support info for (http://localhost:8081):**\nSupport Page: http://localhost\n\n\n * **admin** - [@admin:localhost](https://matrix.to/#/@admin:localhost)\n", `Draupnir did not parse the json as expected.`);
     })
 
     it('Mjölnir can query and display the query results for a partial contacts-only json.', async function () {
@@ -26,7 +26,7 @@ describe("Test: The queryAdmin command", function () {
         const reply_event = await getFirstReply(this.mjolnir.matrixEmitter, this.mjolnir.managementRoomId, async () => {
             return await moderator.sendMessage(this.mjolnir.managementRoomId, { msgtype: 'm.text', body: `!mjolnir queryAdmin http://localhost:7072` });
         });
-        assert.equal(reply_event.content.body, "", `Draupnir did not parse the json as expected: ${reply_event.content.body}.`);
+        assert.equal(reply_event.content.body, "**Support infos for (http://localhost:7072):**\n * **admin** - [@admin:localhost](https://matrix.to/#/@admin:localhost)\n", `Draupnir did not parse the json as expected.`);
     })
 
     it('Mjölnir can query and display the query results for a partial support_page-only json.', async function () {
@@ -37,7 +37,7 @@ describe("Test: The queryAdmin command", function () {
         const reply_event = await getFirstReply(this.mjolnir.matrixEmitter, this.mjolnir.managementRoomId, async () => {
             return await moderator.sendMessage(this.mjolnir.managementRoomId, { msgtype: 'm.text', body: `!mjolnir queryAdmin http://localhost:7071` });
         });
-        assert.equal(reply_event.content.body, "", `Draupnir did not parse the json as expected: ${reply_event.content.body}.`);
+        assert.equal(reply_event.content.body, "**Support Page for (http://localhost:7071):**\nSupport Page: http://localhost\n", `Draupnir did not parse the json as expected.`);
     })
 
     it('Mjölnir can query and display an error for a non well-formed json.', async function () {
@@ -48,6 +48,6 @@ describe("Test: The queryAdmin command", function () {
         const reply_event = await getFirstReply(this.mjolnir.matrixEmitter, this.mjolnir.managementRoomId, async () => {
             return await moderator.sendMessage(this.mjolnir.managementRoomId, { msgtype: 'm.text', body: `!mjolnir queryAdmin http://localhost:7070` });
         });
-        assert.equal(reply_event.content.body, "", `Draupnir did not parse the json as expected: ${reply_event.content.body}.`);
+        assert.equal(reply_event.content.body, "> <@mjolnir-test-user-moderator61610:localhost:9999> !mjolnir queryAdmin http://localhost:7070\nThe request failed with an error: Error: Error during MatrixClient request GET /.well-known/matrix/support: 404 Not Found -- {}.", `Draupnir did not parse the json as expected.`);
     })
 });

--- a/test/integration/commands/queryAdminDetailsTest.ts
+++ b/test/integration/commands/queryAdminDetailsTest.ts
@@ -15,7 +15,7 @@ describe("Test: The queryAdmin command", function () {
         const reply_event = await getFirstReply(this.mjolnir.matrixEmitter, this.mjolnir.managementRoomId, async () => {
             return await moderator.sendMessage(this.mjolnir.managementRoomId, { msgtype: 'm.text', body: `!mjolnir queryAdmin http://localhost:8081` });
         });
-        assert.equal(reply_event.content.body, "**Support info for (http://localhost:8081):**\nSupport Page: http://localhost\n\n\n * **admin** - [@admin:localhost](https://matrix.to/#/@admin:localhost)\n", `Draupnir did not parse the json as expected.`);
+        assert.equal(reply_event.content.body, "**Support info for (http://localhost:8081):**\nSupport Page: http://localhost\n\n\n\n * **admin** - [@admin:localhost](https://matrix.to/#/@admin:localhost)\n\n", `Draupnir did not parse the json as expected.`);
     })
 
     it('Mjölnir can query and display the query results for a partial contacts-only json.', async function () {
@@ -26,7 +26,7 @@ describe("Test: The queryAdmin command", function () {
         const reply_event = await getFirstReply(this.mjolnir.matrixEmitter, this.mjolnir.managementRoomId, async () => {
             return await moderator.sendMessage(this.mjolnir.managementRoomId, { msgtype: 'm.text', body: `!mjolnir queryAdmin http://localhost:7072` });
         });
-        assert.equal(reply_event.content.body, "**Support infos for (http://localhost:7072):**\n * **admin** - [@admin:localhost](https://matrix.to/#/@admin:localhost)\n", `Draupnir did not parse the json as expected.`);
+        assert.equal(reply_event.content.body, "**Support infos for (http://localhost:7072):**\n\n * **admin** - [@admin:localhost](https://matrix.to/#/@admin:localhost)\n\n", `Draupnir did not parse the json as expected.`);
     })
 
     it('Mjölnir can query and display the query results for a partial support_page-only json.', async function () {
@@ -37,7 +37,7 @@ describe("Test: The queryAdmin command", function () {
         const reply_event = await getFirstReply(this.mjolnir.matrixEmitter, this.mjolnir.managementRoomId, async () => {
             return await moderator.sendMessage(this.mjolnir.managementRoomId, { msgtype: 'm.text', body: `!mjolnir queryAdmin http://localhost:7071` });
         });
-        assert.equal(reply_event.content.body, "**Support Page for (http://localhost:7071):**\nSupport Page: http://localhost\n", `Draupnir did not parse the json as expected.`);
+        assert.equal(reply_event.content.body, "**Support Page for (http://localhost:7071):**\nSupport Page: http://localhost\n\n", `Draupnir did not parse the json as expected.`);
     })
 
     it('Mjölnir can query and display an error for a non well-formed json.', async function () {
@@ -48,6 +48,6 @@ describe("Test: The queryAdmin command", function () {
         const reply_event = await getFirstReply(this.mjolnir.matrixEmitter, this.mjolnir.managementRoomId, async () => {
             return await moderator.sendMessage(this.mjolnir.managementRoomId, { msgtype: 'm.text', body: `!mjolnir queryAdmin http://localhost:7070` });
         });
-        assert.equal(reply_event.content.body, "> <@mjolnir-test-user-moderator61610:localhost:9999> !mjolnir queryAdmin http://localhost:7070\nThe request failed with an error: Error: Error during MatrixClient request GET /.well-known/matrix/support: 404 Not Found -- {}.", `Draupnir did not parse the json as expected.`);
+        assert.equal(reply_event.content.body.includes("The request failed with an error: Error: Error during MatrixClient request GET /.well-known/matrix/support:"), true, `Draupnir did not print an error as.`);
     })
 });

--- a/test/integration/commands/queryAdminDetailsTest.ts
+++ b/test/integration/commands/queryAdminDetailsTest.ts
@@ -1,89 +1,85 @@
 import { strict as assert } from "assert";
 
-import { newTestUser } from "../clientHelper";
-import { getMessagesByUserIn } from "../../../src/utils";
+import { newTestUser, noticeListener } from "../clientHelper";
 
 describe("Test: The queryAdmin command", function () {
     // If a test has a timeout while awaitng on a promise then we never get given control back.
     afterEach(function () { this.moderator?.stop(); });
 
     it('Mjölnir can query and display the query results for a complete json.', async function () {
-        let moderator = await newTestUser(this.config.homeserverUrl, { name: { contains: "moderator" } });
+        const moderator = await newTestUser(this.config.homeserverUrl, { name: { contains: "moderator" } });
         this.moderator = moderator;
         await moderator.joinRoom(this.config.managementRoom);
-        moderator.sendMessage(this.mjolnir.managementRoomId, { msgtype: 'm.text.', body: `!mjolnir queryAdmin http://localhost:8081` });
 
-
-        const draupnir = this.config.RUNTIME.client!
-        let draupnirUserId = await draupnir.getUserId();
-
-        // Check if draupnir replied
-        await getMessagesByUserIn(moderator, draupnirUserId, this.mjolnir.managementRoomId, 1000, function (events) {
-            events.map(e => {
-                if (e.type === 'm.room.message') {
-                    assert.equal(e.content.body, "", `Draupnir did not parse the json as expected: ${e.content.body}.`)
-                }
-            })
+        // listener for getting the event reply
+        const reply = new Promise<any>((resolve, reject) => {
+            moderator.on('room.message', noticeListener(this.mjolnir.managementRoomId, (event) => {
+                resolve(event);
+            }))
         });
+
+        await moderator.sendMessage(this.mjolnir.managementRoomId, { msgtype: 'm.text.', body: `!mjolnir queryAdmin http://localhost:8081` });
+
+
+        const reply_event = await reply;
+
+        assert.equal(reply_event.content.body, "", `Draupnir did not parse the json as expected: ${reply_event.content.body}.`)
     })
 
     it('Mjölnir can query and display the query results for a partial contacts-only json.', async function () {
-        let moderator = await newTestUser(this.config.homeserverUrl, { name: { contains: "moderator" } });
+        const moderator = await newTestUser(this.config.homeserverUrl, { name: { contains: "moderator" } });
         this.moderator = moderator;
         await moderator.joinRoom(this.config.managementRoom);
-        moderator.sendMessage(this.mjolnir.managementRoomId, { msgtype: 'm.text.', body: `!mjolnir queryAdmin http://localhost:7072` });
 
-
-        const draupnir = this.config.RUNTIME.client!
-        let draupnirUserId = await draupnir.getUserId();
-
-        // Check if draupnir replied
-        await getMessagesByUserIn(moderator, draupnirUserId, this.mjolnir.managementRoomId, 1000, function (events) {
-            events.map(e => {
-                if (e.type === 'm.room.message') {
-                    assert.equal(e.content.body, "", `Draupnir did not parse the json as expected: ${e.content.body}.`)
-                }
-            })
+        // listener for getting the event reply
+        const reply = new Promise<any>((resolve, reject) => {
+            moderator.on('room.message', noticeListener(this.mjolnir.managementRoomId, (event) => {
+                resolve(event);
+            }))
         });
+
+        await moderator.sendMessage(this.mjolnir.managementRoomId, { msgtype: 'm.text.', body: `!mjolnir queryAdmin http://localhost:7072` });
+
+        const reply_event = await reply;
+
+        assert.equal(reply_event.content.body, "", `Draupnir did not parse the json as expected: ${reply_event.content.body}.`)
     })
 
     it('Mjölnir can query and display the query results for a partial support_page-only json.', async function () {
-        let moderator = await newTestUser(this.config.homeserverUrl, { name: { contains: "moderator" } });
+        const moderator = await newTestUser(this.config.homeserverUrl, { name: { contains: "moderator" } });
         this.moderator = moderator;
         await moderator.joinRoom(this.config.managementRoom);
-        moderator.sendMessage(this.mjolnir.managementRoomId, { msgtype: 'm.text.', body: `!mjolnir queryAdmin http://localhost:7071` });
 
-
-        const draupnir = this.config.RUNTIME.client!
-        let draupnirUserId = await draupnir.getUserId();
-
-        // Check if draupnir replied
-        await getMessagesByUserIn(moderator, draupnirUserId, this.mjolnir.managementRoomId, 1000, function (events) {
-            events.map(e => {
-                if (e.type === 'm.room.message') {
-                    assert.equal(e.content.body, "", `Draupnir did not parse the json as expected: ${e.content.body}.`)
-                }
-            })
+        // listener for getting the event reply
+        const reply = new Promise<any>((resolve, reject) => {
+            moderator.on('room.message', noticeListener(this.mjolnir.managementRoomId, (event) => {
+                resolve(event);
+            }))
         });
+
+        await moderator.sendMessage(this.mjolnir.managementRoomId, { msgtype: 'm.text.', body: `!mjolnir queryAdmin http://localhost:7071` });
+
+        const reply_event = await reply;
+
+        assert.equal(reply_event.content.body, "", `Draupnir did not parse the json as expected: ${reply_event.content.body}.`)
     })
 
     it('Mjölnir can query and display an error for a non well-formed json.', async function () {
-        let moderator = await newTestUser(this.config.homeserverUrl, { name: { contains: "moderator" } });
+        const moderator = await newTestUser(this.config.homeserverUrl, { name: { contains: "moderator" } });
         this.moderator = moderator;
         await moderator.joinRoom(this.config.managementRoom);
+
+        // listener for getting the event reply
+        const reply = new Promise<any>((resolve, reject) => {
+            moderator.on('room.message', noticeListener(this.mjolnir.managementRoomId, (event) => {
+                resolve(event);
+            }))
+        });
+
         moderator.sendMessage(this.mjolnir.managementRoomId, { msgtype: 'm.text.', body: `!mjolnir queryAdmin http://localhost:7070` });
 
+        const reply_event = await reply;
 
-        const draupnir = this.config.RUNTIME.client!
-        let draupnirUserId = await draupnir.getUserId();
-
-        // Check if draupnir replied
-        await getMessagesByUserIn(moderator, draupnirUserId, this.mjolnir.managementRoomId, 1000, function (events) {
-            events.map(e => {
-                if (e.type === 'm.room.message') {
-                    assert.equal(e.content.body, "", `Draupnir did not parse the json as expected: ${e.content.body}.`)
-                }
-            })
-        });
+        assert.equal(reply_event.content.body, "", `Draupnir did not parse the json as expected: ${reply_event.content.body}.`)
     })
 });

--- a/test/integration/commands/queryAdminDetailsTest.ts
+++ b/test/integration/commands/queryAdminDetailsTest.ts
@@ -13,7 +13,7 @@ describe("Test: The queryAdmin command", function () {
         await moderator.joinRoom(this.config.managementRoom);
 
         const reply_event = await getFirstReply(this.mjolnir.matrixEmitter, this.mjolnir.managementRoomId, async () => {
-            return await moderator.sendMessage(this.mjolnir.managementRoomId, { msgtype: 'm.text', body: `!mjolnir queryAdmin http://localhost:8081` });
+            return await moderator.sendMessage(this.mjolnir.managementRoomId, { msgtype: 'm.text', body: `!mjolnir query admin http://localhost:8081` });
         });
         assert.equal(reply_event.content.body, "**Support info for (http://localhost:8081):**\nSupport Page: http://localhost\n\n\n\n * **admin** - [@admin:localhost](https://matrix.to/#/@admin:localhost)\n\n", `Draupnir did not parse the json as expected.`);
     })
@@ -24,7 +24,7 @@ describe("Test: The queryAdmin command", function () {
         await moderator.joinRoom(this.config.managementRoom);
 
         const reply_event = await getFirstReply(this.mjolnir.matrixEmitter, this.mjolnir.managementRoomId, async () => {
-            return await moderator.sendMessage(this.mjolnir.managementRoomId, { msgtype: 'm.text', body: `!mjolnir queryAdmin http://localhost:7072` });
+            return await moderator.sendMessage(this.mjolnir.managementRoomId, { msgtype: 'm.text', body: `!mjolnir query admin http://localhost:7072` });
         });
         assert.equal(reply_event.content.body, "**Support infos for (http://localhost:7072):**\n\n * **admin** - [@admin:localhost](https://matrix.to/#/@admin:localhost)\n\n", `Draupnir did not parse the json as expected.`);
     })
@@ -35,7 +35,7 @@ describe("Test: The queryAdmin command", function () {
         await moderator.joinRoom(this.config.managementRoom);
 
         const reply_event = await getFirstReply(this.mjolnir.matrixEmitter, this.mjolnir.managementRoomId, async () => {
-            return await moderator.sendMessage(this.mjolnir.managementRoomId, { msgtype: 'm.text', body: `!mjolnir queryAdmin http://localhost:7071` });
+            return await moderator.sendMessage(this.mjolnir.managementRoomId, { msgtype: 'm.text', body: `!mjolnir query admin http://localhost:7071` });
         });
         assert.equal(reply_event.content.body, "**Support Page for (http://localhost:7071):**\nSupport Page: http://localhost\n\n", `Draupnir did not parse the json as expected.`);
     })
@@ -46,7 +46,7 @@ describe("Test: The queryAdmin command", function () {
         await moderator.joinRoom(this.config.managementRoom);
 
         const reply_event = await getFirstReply(this.mjolnir.matrixEmitter, this.mjolnir.managementRoomId, async () => {
-            return await moderator.sendMessage(this.mjolnir.managementRoomId, { msgtype: 'm.text', body: `!mjolnir queryAdmin http://localhost:7070` });
+            return await moderator.sendMessage(this.mjolnir.managementRoomId, { msgtype: 'm.text', body: `!mjolnir query admin http://localhost:7070` });
         });
         assert.equal(reply_event.content.body.includes("The request failed with an error: Error: Error during MatrixClient request GET /.well-known/matrix/support:"), true, `Draupnir did not print an error as.`);
     })

--- a/test/nginx.conf
+++ b/test/nginx.conf
@@ -4,29 +4,74 @@ events {
 
 http {
     server {
-    listen [::]:8081 ipv6only=off;
+        listen [::]:8081 ipv6only=off;
 
-    location ~ ^/_matrix/client/(r0|v3)/rooms/([^/]*)/report/(.*)$ {
-        # Abuse reports should be sent to Mjölnir.
-        # The r0 endpoint is deprecated but still used by many clients.
-        # As of this writing, the v3 endpoint is the up-to-date version.
+        location ~ ^/_matrix/client/(r0|v3)/rooms/([^/]*)/report/(.*)$ {
+            # Abuse reports should be sent to Mjölnir.
+            # The r0 endpoint is deprecated but still used by many clients.
+            # As of this writing, the v3 endpoint is the up-to-date version.
 
-        # Add CORS, otherwise a browser will refuse this request.
-        add_header 'Access-Control-Allow-Origin' '*' always; # Note: '*' is for testing purposes. For your own server, you probably want to tighten this.
-        add_header 'Access-Control-Allow-Credentials' 'true' always;
-        add_header 'Access-Control-Allow-Methods' 'GET, POST, OPTIONS' always;
-        add_header 'Access-Control-Allow-Headers' 'Authorization,Content-Type,Accept,Origin,User-Agent,DNT,Cache-Control,X-Mx-ReqToken,Keep-Alive,X-Requested-With,If-Modified-Since' always;
-        add_header 'Access-Control-Expose-Headers' 'Content-Length,Content-Range' always;
-        add_header 'Access-Control-Max-Age' 1728000; # cache preflight value for 20 days
+            # Add CORS, otherwise a browser will refuse this request.
+            add_header 'Access-Control-Allow-Origin' '*' always; # Note: '*' is for testing purposes. For your own server, you probably want to tighten this.
+            add_header 'Access-Control-Allow-Credentials' 'true' always;
+            add_header 'Access-Control-Allow-Methods' 'GET, POST, OPTIONS' always;
+            add_header 'Access-Control-Allow-Headers' 'Authorization,Content-Type,Accept,Origin,User-Agent,DNT,Cache-Control,X-Mx-ReqToken,Keep-Alive,X-Requested-With,If-Modified-Since' always;
+            add_header 'Access-Control-Expose-Headers' 'Content-Length,Content-Range' always;
+            add_header 'Access-Control-Max-Age' 1728000; # cache preflight value for 20 days
 
-        # Alias the regexps, to ensure that they're not rewritten.
-        set $room_id $2;
-        set $event_id $3;
-        proxy_pass http://127.0.0.1:8082/api/1/report/$room_id/$event_id;
+            # Alias the regexps, to ensure that they're not rewritten.
+            set $room_id $2;
+            set $event_id $3;
+            proxy_pass http://127.0.0.1:8082/api/1/report/$room_id/$event_id;
+        }
+        # MSC1929 Test in best-case
+        location /.well-known/matrix/support {
+            default_type application/json;
+            return 200 '{
+                "contacts": [{
+                    "matrix_id": "@admin:localhost",
+                    "role": "admin"
+                }],
+                "support_page": "http://localhost"
+            }';
+        }
+        location / {
+            # Everything else should be sent to Synapse.
+            proxy_pass http://127.0.0.1:9999;
+        }
     }
-    location / {
-        # Everything else should be sent to Synapse.
-        proxy_pass http://127.0.0.1:9999;
+    server {
+        listen [::]:8084 ipv6only=off;
+
+        # MSC1929 Test in worst-case
+        location /.well-known/matrix/support {
+            default_type application/json;
+            return 404 '{}';
+        }
+    }
+    server {
+        listen [::]:8085 ipv6only=off;
+
+        # MSC1929 Test in supportpage_only-case
+        location /.well-known/matrix/support {
+            default_type application/json;
+            return 200 '{
+                "support_page": "http://localhost"
+            }';
+        }
+    }
+    server {
+        listen [::]:8086 ipv6only=off;
+
+        # MSC1929 Test in contacts-case
+        location /.well-known/matrix/support {
+            default_type application/json;
+            return 200 '{
+                "contacts": [{
+                    "matrix_id": "@admin:localhost",
+                    "role": "admin"
+                }],
+            }';
         }
     }
 }

--- a/test/nginx.conf
+++ b/test/nginx.conf
@@ -6,7 +6,7 @@ http {
     server {
         listen [::]:8081 ipv6only=off;
 
-        location ~ ^/_matrix/client/(r0|v3)/rooms/([^/]*)/report/(.*)$ {
+        location ~ ^/_matrix/client/(r0|v3)/rooms/([^/\s]*)/report/(.*)$ {
             # Abuse reports should be sent to Mjölnir.
             # The r0 endpoint is deprecated but still used by many clients.
             # As of this writing, the v3 endpoint is the up-to-date version.
@@ -41,7 +41,7 @@ http {
         }
     }
     server {
-        listen [::]:8084 ipv6only=off;
+        listen [::]:7070 ipv6only=off;
 
         # MSC1929 Test in worst-case
         location /.well-known/matrix/support {
@@ -50,7 +50,7 @@ http {
         }
     }
     server {
-        listen [::]:8085 ipv6only=off;
+        listen [::]:7071 ipv6only=off;
 
         # MSC1929 Test in supportpage_only-case
         location /.well-known/matrix/support {
@@ -61,7 +61,7 @@ http {
         }
     }
     server {
-        listen [::]:8086 ipv6only=off;
+        listen [::]:7072 ipv6only=off;
 
         # MSC1929 Test in contacts-case
         location /.well-known/matrix/support {

--- a/test/nginx.conf
+++ b/test/nginx.conf
@@ -70,7 +70,7 @@ http {
                 "contacts": [{
                     "matrix_id": "@admin:localhost",
                     "role": "admin"
-                }],
+                }]
             }';
         }
     }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -33,5 +33,6 @@
         "./test/integration/protectionSettingsTest.ts",
         "./test/integration/banPropagationTest.ts",
         "./test/integration/protectedRoomsConfigTest.ts",
+        "./test/integration/commands/queryAdminDetailsTest.ts",
     ]
 }


### PR DESCRIPTION
Adds a command to query the MSC1929 JSON and display it. It also adds tests for this.

---

Some example output:

All infos available:

> **Support info for (http://localhost:8081):**
> Support Page: http://localhost
> 
>  * **admin** - [@admin:localhost](https://matrix.to/#/@admin:localhost)

Only users available:

> **Support info for (http://localhost:8081):**
> 
>  * **admin** - [@admin:localhost](https://matrix.to/#/@admin:localhost)

Only Support page available:

> **Support info for (http://localhost:8081):**
> Support Page: http://localhost

