### PR TITLE
Change license to AFL-3.0 [Contributors please read & respond]

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,19 +1,5 @@
 # Contributing code to Draupnir
 
-Draupnir is licensed under the Cooperative Software License.
-The reason for the license is simply because this project
-was something that I was previously employed to work on.
-
-I have not decided whether I will accept contributions under the
-same license or another license or a CLA yet.
-I will welcome advice, but I will not welcome attempts to parsuade
-me to re-adopt and relicense under Apache-2.0 unless being offered
-compensation.
-
-As of now, I am accepting contributions under the Apache-2.0 license
-in the same way as Mjolnir. This allows me the option to relicense
-Draupnir under Apache-2.0 without needing to chase up all contributors.
-
 ## How to contribute
 
 The preferred and easiest way to contribute changes to Matrix is to fork the

--- a/LICENSE
+++ b/LICENSE
@@ -1,415 +1,172 @@
-Draupnir
-Copyright Gnuxie <Gnuxie@protonmail.com> 2022
+Academic Free License ("AFL") v. 3.0
 
-COOPERATIVE SOFTWARE LICENSE
+This Academic Free License (the "License") applies to any original work of
+authorship (the "Original Work") whose owner (the "Licensor") has placed the
+following licensing notice adjacent to the copyright notice for the Original
+Work:
 
-THE WORK (AS DEFINED BELOW) IS PROVIDED UNDER THE TERMS OF THIS
-COOPERATIVE SOFTWARE LICENSE ("LICENSE"). THE WORK IS PROTECTED BY
-COPYRIGHT AND ALL OTHER APPLICABLE LAWS. ANY USE OF THE WORK OTHER THAN
-AS AUTHORIZED UNDER THIS LICENSE OR COPYRIGHT LAW IS PROHIBITED. BY
-EXERCISING ANY RIGHTS TO THE WORK PROVIDED IN THIS LICENSE, YOU AGREE
-TO BE BOUND BY THE TERMS OF THIS LICENSE. TO THE EXTENT THIS LICENSE
-MAY BE CONSIDERED TO BE A CONTRACT, THE LICENSOR GRANTS YOU THE RIGHTS
-CONTAINED HERE IN AS CONSIDERATION FOR ACCEPTING THE TERMS AND
-CONDITIONS OF THIS LICENSE AND FOR AGREEING TO BE BOUND BY THE TERMS
-AND CONDITIONS OF THIS LICENSE.
+  Licensed under the Academic Free License version 3.0
 
-1. DEFINITIONS
+1) Grant of Copyright License. Licensor grants You a worldwide, royalty-free,
+non-exclusive, sublicensable license, for the duration of the copyright, to do
+the following:
 
-          a. "Adaptation" means a work based upon the Work, or upon the
-          Work and other pre-existing works, such as a translation,
-          adaptation, derivative work, arrangement of music or other
-          alterations of a literary or artistic work, or phonogram or
-          performance and includes cinematographic adaptations or any
-          other form in which the Work may be recast, transformed, or
-          adapted including in any form recognizably derived from the
-          original, except that a work that constitutes a Collection will
-          not be considered an Adaptation for the purpose of this License.
-          For the avoidance of doubt, where the Work is a musical work,
-          performance or phonogram, the synchronization of the Work in
-          timed-relation with a moving image ("synching") will be
-          considered an Adaptation for the purpose of this License.
+  a) to reproduce the Original Work in copies, either alone or as part of a
+  collective work;
 
-          b. "Collection" means a collection of literary or artistic
-          works, such as encyclopedias and anthologies, or performances,
-          phonograms or broadcasts, or other works or subject matter other
-          than works listed in Section 1(f) below, which, by reason of the
-          selection and arrangement of their contents, constitute
-          intellectual creations, in which the Work is included in its
-          entirety in unmodified form along with one or more other
-          contributions, each constituting separate and independent works
-          in themselves, which together are assembled into a collective
-          whole. A work that constitutes a Collection will not be
-          considered an Adaptation (as defined above) for the purposes of
-          this License.
+  b) to translate, adapt, alter, transform, modify, or arrange the Original
+  Work, thereby creating derivative works ("Derivative Works") based upon the
+  Original Work;
 
-          c. "Distribute" means to make available to the public the
-          original and copies of the Work or Adaptation, as appropriate,
-          through sale, gift or any other transfer of possession or
-          ownership.
+  c) to distribute or communicate copies of the Original Work and Derivative
+  Works to the public, under any license of your choice that does not
+  contradict the terms and conditions, including Licensor's reserved rights
+  and remedies, in this Academic Free License;
 
-          d. "Licensor" means the individual, individuals, entity or
-          entities that offer(s) the Work under the terms of this License.
+  d) to perform the Original Work publicly; and
 
-          e. "Original Author" means, in the case of a literary or
-          artistic work, the individual, individuals, entity or entities
-          who created the Work or if no individual or entity can be
-          identified, the publisher; and in addition (i) in the case of a
-          performance the actors, singers, musicians, dancers, and other
-          persons who act, sing, deliver, declaim, play in, interpret or
-          otherwise perform literary or artistic works or expressions of
-          folklore; (ii) in the case of a phonogram the producer being the
-          person or legal entity who first fixes the sounds of a
-          performance or other sounds; and, (iii) in the case of
-          broadcasts, the organization that transmits the broadcast.
+  e) to display the Original Work publicly.
 
-          f. "Work" means the literary and/or artistic work offered under
-          the terms of this License including without limitation any
-          production in the literary, scientific and artistic domain,
-          whatever may be the mode or form of its expression including
-          digital form, such as a book, pamphlet and other writing; a
-          lecture, address, sermon or other work of the same nature; a
-          dramatic or dramatico-musical work; a choreographic work or
-          entertainment in dumb show; a musical composition with or
-          without words; a cinematographic work to which are assimilated
-          works expressed by a process analogous to cinematography; a work
-          of drawing, painting, architecture, sculpture, engraving or
-          lithography; a photographic work to which are assimilated works
-          expressed by a process analogous to photography; a work of
-          applied art; an illustration, map, plan, sketch or
-          three-dimensional work relative to geography, topography,
-          architecture or science; a performance; a broadcast; a
-          phonogram; a compilation of data to the extent it is protected
-          as a copyrightable work; or a work performed by a variety or
-          circus performer to the extent it is not otherwise considered a
-          literary or artistic work.
+2) Grant of Patent License. Licensor grants You a worldwide, royalty-free,
+non-exclusive, sublicensable license, under patent claims owned or controlled
+by the Licensor that are embodied in the Original Work as furnished by the
+Licensor, for the duration of the patents, to make, use, sell, offer for sale,
+have made, and import the Original Work and Derivative Works.
 
-          g. "You" means an individual or entity exercising rights under
-          this License who has not previously violated the terms of this
-          License with respect to the Work, or who has received express
-          permission from the Licensor to exercise rights under this
-          License despite a previous violation.
+3) Grant of Source Code License. The term "Source Code" means the preferred
+form of the Original Work for making modifications to it and all available
+documentation describing how to modify the Original Work. Licensor agrees to
+provide a machine-readable copy of the Source Code of the Original Work along
+with each copy of the Original Work that Licensor distributes. Licensor
+reserves the right to satisfy this obligation by placing a machine-readable
+copy of the Source Code in an information repository reasonably calculated to
+permit inexpensive and convenient access by You for as long as Licensor
+continues to distribute the Original Work.
 
-          h. "Publicly Perform" means to perform public recitations of the
-          Work and to communicate to the public those public recitations,
-          by any means or process, including by wire or wireless means or
-          public digital performances; to make available to the public
-          Works in such a way that members of the public may access these
-          Works from a place and at a place individually chosen by them;
-          to perform the Work to the public by any means or process and
-          the communication to the public of the performances of the Work,
-          including by public digital performance; to broadcast and
-          rebroadcast the Work by any means including signs, sounds or
-          images.
+4) Exclusions From License Grant. Neither the names of Licensor, nor the names
+of any contributors to the Original Work, nor any of their trademarks or
+service marks, may be used to endorse or promote products derived from this
+Original Work without express prior permission of the Licensor. Except as
+expressly stated herein, nothing in this License grants any license to
+Licensor's trademarks, copyrights, patents, trade secrets or any other
+intellectual property. No patent license is granted to make, use, sell, offer
+for sale, have made, or import embodiments of any patent claims other than the
+licensed claims defined in Section 2. No license is granted to the trademarks
+of Licensor even if such marks are included in the Original Work. Nothing in
+this License shall be interpreted to prohibit Licensor from licensing under
+terms different from this License any Original Work that Licensor otherwise
+would have a right to license.
 
-          i. "Reproduce" means to make copies of the Work by any means
-          including without limitation by sound or visual recordings and
-          the right of fixation and reproducing fixations of the Work,
-          including storage of a protected performance or phonogram in
-          digital form or other electronic medium.
+5) External Deployment. The term "External Deployment" means the use,
+distribution, or communication of the Original Work or Derivative Works in any
+way such that the Original Work or Derivative Works may be used by anyone
+other than You, whether those works are distributed or communicated to those
+persons or made available as an application intended for use over a network.
+As an express condition for the grants of license hereunder, You must treat
+any External Deployment by You of the Original Work or a Derivative Work as a
+distribution under section 1(c).
 
-          j. "Software" means any digital Work which, through use of a
-          third-party piece of Software or through the direct usage of
-          itself on a computer system, the memory of the computer is
-          modified dynamically or semi-dynamically. "Software",
-          secondly, processes or interprets information.
+6) Attribution Rights. You must retain, in the Source Code of any Derivative
+Works that You create, all copyright, patent, or trademark notices from the
+Source Code of the Original Work, as well as any notices of licensing and any
+descriptive text identified therein as an "Attribution Notice." You must cause
+the Source Code for any Derivative Works that You create to carry a prominent
+Attribution Notice reasonably calculated to inform recipients that You have
+modified the Original Work.
 
-          k. "Source Code" means the human-readable form of Software
-          through which the Original Author and/or Distributor originally
-          created, derived, and/or modified it.
+7) Warranty of Provenance and Disclaimer of Warranty. Licensor warrants that
+the copyright in and to the Original Work and the patent rights granted herein
+by Licensor are owned by the Licensor or are sublicensed to You under the
+terms of this License with the permission of the contributor(s) of those
+copyrights and patent rights. Except as expressly stated in the immediately
+preceding sentence, the Original Work is provided under this License on an "AS
+IS" BASIS and WITHOUT WARRANTY, either express or implied, including, without
+limitation, the warranties of non-infringement, merchantability or fitness for
+a particular purpose. THE ENTIRE RISK AS TO THE QUALITY OF THE ORIGINAL WORK
+IS WITH YOU. This DISCLAIMER OF WARRANTY constitutes an essential part of this
+License. No license to the Original Work is granted by this License except
+under this disclaimer.
 
-          l. "Network Service" means the use of a piece of Software to
-          interpret or modify information that is subsequently and directly
-          served to users over a public computer network.
+8) Limitation of Liability. Under no circumstances and under no legal theory,
+whether in tort (including negligence), contract, or otherwise, shall the
+Licensor be liable to anyone for any indirect, special, incidental, or
+consequential damages of any character arising as a result of this License or
+the use of the Original Work including, without limitation, damages for loss
+of goodwill, work stoppage, computer failure or malfunction, or any and all
+other commercial damages or losses. This limitation of liability shall not
+apply to the extent applicable law prohibits such limitation.
 
-2. FAIR DEALING RIGHTS
+9) Acceptance and Termination. If, at any time, You expressly assented to this
+License, that assent indicates your clear and irrevocable acceptance of this
+License and all of its terms and conditions. If You distribute or communicate
+copies of the Original Work or a Derivative Work, You must make a reasonable
+effort under the circumstances to obtain the express assent of recipients to
+the terms of this License. This License conditions your rights to undertake
+the activities listed in Section 1, including your right to create Derivative
+Works based upon the Original Work, and doing so without honoring these terms
+and conditions is prohibited by copyright law and international treaty.
+Nothing in this License is intended to affect copyright exceptions and
+limitations (including "fair use" or "fair dealing"). This License shall
+terminate immediately and You may no longer exercise any of the rights granted
+to You by this License upon your failure to honor the conditions in Section
+1(c).
 
-   Nothing in this License is intended to reduce, limit, or restrict any
-   uses free from copyright or rights arising from limitations or
-   exceptions that are provided for in connection with the copyright
-   protection under copyright law or other applicable laws.
+10) Termination for Patent Action. This License shall terminate automatically
+and You may no longer exercise any of the rights granted to You by this
+License as of the date You commence an action, including a cross-claim or
+counterclaim, against Licensor or any licensee alleging that the Original Work
+infringes a patent. This termination provision shall not apply for an action
+alleging patent infringement by combinations of the Original Work with other
+software or hardware.
 
-3. LICENSE GRANT
+11) Jurisdiction, Venue and Governing Law. Any action or suit relating to this
+License may be brought only in the courts of a jurisdiction wherein the
+Licensor resides or in which Licensor conducts its primary business, and under
+the laws of that jurisdiction excluding its conflict-of-law provisions. The
+application of the United Nations Convention on Contracts for the
+International Sale of Goods is expressly excluded. Any use of the Original
+Work outside the scope of this License or after its termination shall be
+subject to the requirements and penalties of copyright or patent law in the
+appropriate jurisdiction. This section shall survive the termination of this
+License.
 
-   Subject to the terms and conditions of this License, Licensor hereby
-   grants You a worldwide, royalty-free, non-exclusive, perpetual (for the
-   duration of the applicable copyright) license to exercise the rights in
-   the Work as stated below:
+12) Attorneys' Fees. In any action to enforce the terms of this License or
+seeking damages relating thereto, the prevailing party shall be entitled to
+recover its costs and expenses, including, without limitation, reasonable
+attorneys' fees and costs incurred in connection with such action, including
+any appeal of such action. This section shall survive the termination of this
+License.
 
-          a. to Reproduce the Work, to incorporate the Work into one or
-          more Collections, and to Reproduce the Work as incorporated in
-          the Collections;
+13) Miscellaneous. If any provision of this License is held to be
+unenforceable, such provision shall be reformed only to the extent necessary
+to make it enforceable.
 
-          b. to create and Reproduce Adaptations provided that any such
-          Adaptation, including any translation in any medium, takes
-          reasonable steps to clearly label, demarcate or otherwise
-          identify that changes were made to the original Work. For
-          example, a translation could be marked "The original work was
-          translated from English to Spanish," or a modification could
-          indicate "The original work has been modified.";
+14) Definition of "You" in This License. "You" throughout this License,
+whether in upper or lower case, means an individual or a legal entity
+exercising rights under, and complying with all of the terms of, this License.
+For legal entities, "You" includes any entity that controls, is controlled by,
+or is under common control with you. For purposes of this definition,
+"control" means (i) the power, direct or indirect, to cause the direction or
+management of such entity, whether by contract or otherwise, or (ii) ownership
+of fifty percent (50%) or more of the outstanding shares, or (iii) beneficial
+ownership of such entity.
 
-          c. to Distribute and Publicly Perform the Work including as
-          incorporated in Collections; and,
+15) Right to Use. You may use the Original Work in all ways not otherwise
+restricted or conditioned by this License or by law, and Licensor promises not
+to interfere with or be responsible for such uses by You.
 
-          d. to Distribute and Publicly Perform Adaptations. The above
-          rights may be exercised in all media and formats whether now
-          known or hereafter devised. The above rights include the right
-          to make such modifications as are technically necessary to
-          exercise the rights in other media and formats. Subject to
-          Section 8(g), all rights not expressly granted by Licensor are
-          hereby reserved, including but not limited to the rights set
-          forth in Section 4(h).
-
-4. RESTRICTIONS
-
-   The license granted in Section 3 above is expressly made subject to and
-   limited by the following restrictions:
-
-          a. You may Distribute or Publicly Perform the Work only under
-          the terms of this License. You must include a copy of, or the
-          Uniform Resource Identifier (URI) for, this License with every
-          copy of the Work You Distribute or Publicly Perform. You may not
-          offer or impose any terms on the Work that restrict the terms of
-          this License or the ability of the recipient of the Work to
-          exercise the rights granted to that recipient under the terms of
-          the License. You may not sublicense the Work. You must keep
-          intact all notices that refer to this License and to the
-          disclaimer of warranties with every copy of the Work You
-          Distribute or Publicly Perform. When You Distribute or Publicly
-          Perform the Work, You may not impose any effective technological
-          measures on the Work that restrict the ability of a recipient of
-          the Work from You to exercise the rights granted to that
-          recipient under the terms of the License. This Section 4(a)
-          applies to the Work as incorporated in a Collection, but this
-          does not require the Collection apart from the Work itself to be
-          made subject to the terms of this License. If You create a
-          Collection, upon notice from any Licensor You must, to the
-          extent practicable, remove from the Collection any credit as
-          required by Section 4(f), as requested. If You create an
-          Adaptation, upon notice from any Licensor You must, to the
-          extent practicable, remove from the Adaptation any credit as
-          required by Section 4(f), as requested.
-
-          b. Subject to the exception in Section 4(e), you may not
-          exercise any of the rights granted to You in Section 3 above in
-          any manner that is primarily intended for or directed toward
-          commercial advantage or private monetary compensation. The
-          exchange of the Work for other copyrighted works by means of
-          digital file-sharing or otherwise shall not be considered to be
-          intended for or directed toward commercial advantage or private
-          monetary compensation, provided there is no payment of any
-          monetary compensation in connection with the exchange of
-          copyrighted works.
-
-          c. If the Work meets the definition of Software, You may exercise
-          the rights granted in Section 3 only if You provide a copy of the
-          corresponding Source Code from which the Work was derived in digital
-          form, or You provide a URI for the corresponding Source Code of
-          the Work, to any recipients upon request.
-
-          d. If the Work is used as or for a Network Service, You may exercise
-          the rights granted in Section 3 only if You provide a copy of the
-          corresponding Source Code from which the Work was derived in digital
-          form, or You provide a URI for the corresponding Source Code to the
-          Work, to any recipients of the data served or modified by the Network
-          Service.
-
-          e. You may exercise the rights granted in Section 3 for
-          commercial purposes only if:
-
-                i. You are a worker-owned business or worker-owned
-                collective; and
-                ii.  after tax, all financial gain, surplus, profits and
-                benefits produced by the business or collective are
-                distributed among the worker-owners; and
-		iii. You are not using such rights on behalf of a business
-		other than those specified in 4(e.i) and elaborated upon in
-                4(e.ii), nor are using such rights as a proxy on behalf of a
-                business with the intent to circumvent the aforementioned
-                restrictions on such a business.
-
-          f. Any use by a business that is privately owned and managed,
-          and that seeks to generate profit from the labor of employees
-          paid by salary or other wages, is not permitted under this
-          license.
-
-          g. If You Distribute, or Publicly Perform the Work or any
-          Adaptations or Collections, You must, unless a request has been
-          made pursuant to Section 4(a), keep intact all copyright notices
-          for the Work and provide, reasonable to the medium or means You
-          are utilizing: (i) the name of the Original Author (or
-          pseudonym, if applicable) if supplied, and/or if the Original
-          Author and/or Licensor designate another party or parties (e.g.,
-          a sponsor institute, publishing entity, journal) for attribution
-          ("Attribution Parties") in Licensor's copyright notice, terms of
-          service or by other reasonable means, the name of such party or
-          parties; (ii) the title of the Work if supplied; (iii) to the
-          extent reasonably practicable, the URI, if any, that Licensor
-          specifies to be associated with the Work, unless such URI does
-          not refer to the copyright notice or licensing information for
-          the Work; and, (iv) consistent with Section 3(b), in the case of
-          an Adaptation, a credit identifying the use of the Work in the
-          Adaptation (e.g., "French translation of the Work by Original
-          Author," or "Screenplay based on original Work by Original
-          Author"). The credit required by this Section 4(g) may be
-          implemented in any reasonable manner; provided, however, that in
-          the case of a Adaptation or Collection, at a minimum such credit
-          will appear, if a credit for all contributing authors of the
-          Adaptation or Collection appears, then as part of these credits
-          and in a manner at least as prominent as the credits for the
-          other contributing authors. For the avoidance of doubt, You may
-          only use the credit required by this Section for the purpose of
-          attribution in the manner set out above and, by exercising Your
-          rights under this License, You may not implicitly or explicitly
-          assert or imply any connection with, sponsorship or endorsement
-          by the Original Author, Licensor and/or Attribution Parties, as
-          appropriate, of You or Your use of the Work, without the
-          separate, express prior written permission of the Original
-          Author, Licensor and/or Attribution Parties.
-
-          h. For the avoidance of doubt:
-
-                i. Non-waivable Compulsory License Schemes. In those
-                jurisdictions in which the right to collect royalties
-                through any statutory or compulsory licensing scheme
-                cannot be waived, the Licensor reserves the exclusive
-                right to collect such royalties for any exercise by You of
-                the rights granted under this License;
-
-                ii. Waivable Compulsory License Schemes. In those
-                jurisdictions in which the right to collect royalties
-                through any statutory or compulsory licensing scheme can
-                be waived, the Licensor reserves the exclusive right to
-                collect such royalties for any exercise by You of the
-                rights granted under this License if Your exercise of such
-                rights is for a purpose or use which is otherwise than
-                noncommercial as permitted under Section 4(b) and
-                otherwise waives the right to collect royalties through
-                any statutory or compulsory licensing scheme; and,
-                iii.Voluntary License Schemes. The Licensor reserves the
-                right to collect royalties, whether individually or, in
-                the event that the Licensor is a member of a collecting
-                society that administers voluntary licensing schemes, via
-                that society, from any exercise by You of the rights
-                granted under this License that is for a purpose or use
-                which is otherwise than noncommercial as permitted under
-                Section 4(b).
-
-          i. Except as otherwise agreed in writing by the Licensor or as
-          may be otherwise permitted by applicable law, if You Reproduce,
-          Distribute or Publicly Perform the Work either by itself or as
-          part of any Adaptations or Collections, You must not distort,
-          mutilate, modify or take other derogatory action in relation to
-          the Work which would be prejudicial to the Original Author's
-          honor or reputation. Licensor agrees that in those jurisdictions
-          (e.g. Japan), in which any exercise of the right granted in
-          Section 3(b) of this License (the right to make Adaptations)
-          would be deemed to be a distortion, mutilation, modification or
-          other derogatory action prejudicial to the Original Author's
-          honor and reputation, the Licensor will waive or not assert, as
-          appropriate, this Section, to the fullest extent permitted by
-          the applicable national law, to enable You to reasonably
-          exercise Your right under Section 3(b) of this License (right to
-          make Adaptations) but not otherwise.
-
-5. REPRESENTATIONS, WARRANTIES AND DISCLAIMER
-
-   UNLESS OTHERWISE MUTUALLY AGREED TO BY THE PARTIES IN WRITING, LICENSOR
-   OFFERS THE WORK AS-IS AND MAKES NO REPRESENTATIONS OR WARRANTIES OF ANY
-   KIND CONCERNING THE WORK, EXPRESS, IMPLIED, STATUTORY OR OTHERWISE,
-   INCLUDING, WITHOUT LIMITATION, WARRANTIES OF TITLE, MERCHANTIBILITY,
-   FITNESS FOR A PARTICULAR PURPOSE, NONINFRINGEMENT, OR THE ABSENCE OF
-   LATENT OR OTHER DEFECTS, ACCURACY, OR THE PRESENCE OF ABSENCE OF
-   ERRORS, WHETHER OR NOT DISCOVERABLE. SOME JURISDICTIONS DO NOT ALLOW
-   THE EXCLUSION OF IMPLIED WARRANTIES, SO SUCH EXCLUSION MAY NOT APPLY TO
-   YOU.
-
-6. LIMITATION ON LIABILITY
-
-   EXCEPT TO THE EXTENT REQUIRED BY APPLICABLE LAW, IN NO EVENT WILL
-   LICENSOR BE LIABLE TO YOU ON ANY LEGAL THEORY FOR ANY SPECIAL,
-   INCIDENTAL, CONSEQUENTIAL, PUNITIVE OR EXEMPLARY DAMAGES ARISING OUT OF
-   THIS LICENSE OR THE USE OF THE WORK, EVEN IF LICENSOR HAS BEEN ADVISED
-   OF THE POSSIBILITY OF SUCH DAMAGES.
-
-7. TERMINATION
-
-          a. This License and the rights granted hereunder will terminate
-          automatically upon any breach by You of the terms of this
-          License. Individuals or entities who have received Adaptations
-          or Collections from You under this License, however, will not
-          have their licenses terminated provided such individuals or
-          entities remain in full compliance with those licenses. Sections
-          1, 2, 5, 6, 7, and 8 will survive any termination of this
-          License.
-
-          b. Subject to the above terms and conditions, the license
-          granted here is perpetual (for the duration of the applicable
-          copyright in the Work). Notwithstanding the above, Licensor
-          reserves the right to release the Work under different license
-          terms or to stop distributing the Work at any time; provided,
-          however that any such election will not serve to withdraw this
-          License (or any other license that has been, or is required to
-          be, granted under the terms of this License), and this License
-          will continue in full force and effect unless terminated as
-          stated above.
-
-8. MISCELLANEOUS
-
-          a. Each time You Distribute or Publicly Perform the Work or a
-          Collection, the Licensor offers to the recipient a license to
-          the Work on the same terms and conditions as the license granted
-          to You under this License.
-
-          b. Each time You Distribute or Publicly Perform an Adaptation,
-          Licensor offers to the recipient a license to the original Work
-          on the same terms and conditions as the license granted to You
-          under this License.
-
-          c. If the Work is classified as Software, each time You Distribute
-          or Publicly Perform an Adaptation, Licensor offers to the recipient
-          a copy and/or URI of the corresponding Source Code on the same
-          terms and conditions as the license granted to You under this License.
-
-          d. If the Work is used as a Network Service, each time You Distribute
-          or Publicly Perform an Adaptation, or serve data derived from the
-          Software, the Licensor offers to any recipients of the data a copy
-          and/or URI of the corresponding Source Code on the same terms and
-          conditions as the license granted to You under this License.
-
-          e. If any provision of this License is invalid or unenforceable
-          under applicable law, it shall not affect the validity or
-          enforceability of the remainder of the terms of this License,
-          and without further action by the parties to this agreement,
-          such provision shall be reformed to the minimum extent necessary
-          to make such provision valid and enforceable.
-
-          f. No term or provision of this License shall be deemed waived
-          and no breach consented to unless such waiver or consent shall
-          be in writing and signed by the party to be charged with such
-          waiver or consent.
-
-          g. This License constitutes the entire agreement between the
-          parties with respect to the Work licensed here. There are no
-          understandings, agreements or representations with respect to
-          the Work not specified here. Licensor shall not be bound by any
-          additional provisions that may appear in any communication from
-          You. This License may not be modified without the mutual written
-          agreement of the Licensor and You.
-
-          h. The rights granted under, and the subject matter referenced,
-          in this License were drafted utilizing the terminology of the
-          Berne Convention for the Protection of Literary and Artistic
-          Works (as amended on September 28, 1979), the Rome Convention of
-          1961, the WIPO Copyright Treaty of 1996, the WIPO Performances
-          and Phonograms Treaty of 1996 and the Universal Copyright
-          Convention (as revised on July 24, 1971). These rights and
-          subject matter take effect in the relevant jurisdiction in which
-          the License terms are sought to be enforced according to the
-          corresponding provisions of the implementation of those treaty
-          provisions in the applicable national law. If the standard suite
-          of rights granted under applicable copyright law includes
-          additional rights not granted under this License, such
-          additional rights are deemed to be included in the License; this
-          License is not intended to restrict the license of any rights
-          under applicable law.
+16) Modification of This License. This License is Copyright © 2005 Lawrence
+Rosen. Permission is granted to copy, distribute, or communicate this License
+without modification. Nothing in this License permits You to modify this
+License as applied to the Original Work or to Derivative Works. However, You
+may modify the text of this License and copy, distribute or communicate your
+modified version (the "Modified License") and apply it to other original works
+of authorship subject to the following conditions: (i) You may not indicate in
+any way that your Modified License is the "Academic Free License" or "AFL" and
+you may not use those names in the name of your Modified License; (ii) You
+must replace the notice specified in the first paragraph above with the notice
+"Licensed under <insert your license name here>" or with a notice of your own
+that is not confusingly similar to the notice in this License; and (iii) You
+may not claim that your original works are open source software unless your
+Modified License has been approved by Open Source Initiative (OSI) and You
+comply with its license review and certification process.

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "lib/index.js",
   "repository": "https://github.com/Gnuxie/Draupnir.git",
   "author": "Gnuxie",
-  "license": "SEE LICENSE IN LICENSE",
+  "license": "AFL-3.0",
   "private": true,
   "scripts": {
     "build": "tsc",


### PR DESCRIPTION
Please reply with 👍 or approve this PR if you agree to relicense your work under the [Academic Free License](https://opensource.org/license/afl-3-0-php/)

As discussed in #176 we want to change the license to AFL-3.0 so that we have an approved open source license with a condition for distribution or incorporation to provide the source code for the original work (or a link to it and this is implemented currently via the status command. I think we should go a step further and provide the notices file here too as a follow up). 

Contributors previously were asked to agree to provide their [contribution](https://github.com/the-draupnir-project/Draupnir/blob/56e03e9/CONTRIBUTING.md#contributing-code-to-draupnir) under the Apache-2.0 license so that I would be the sole author contributing under the project's [Cooperative Software License](https://github.com/the-draupnir-project/Draupnir/blob/56e03e9/LICENSE), which would in (dubious) theory make relicensing to anything Apache-2.0 compatible straight forward later on. However out of an abundance of caution I would like all the authors who have contributed since forking (to cover the case that someone believes they have contributed under the CSL and not Apache-2.0, and therefore can object) to agree to the license change. This also leaves a concrete paper trail in one place rather than each PR.

Contributors:

- [x] @Mikaela 
- [x] @MTRNord 
- [x] @julianfoad 
- [x] @FSG-Cat 
- [x] @JokerGermany 
- [x] @progval 