### PR TITLE
Change self references from Gnuxie/Draupnir to the-draupnir-project/Draupnir

### DIFF
--- a/docs/setup_selfbuild.md
+++ b/docs/setup_selfbuild.md
@@ -2,7 +2,7 @@ These instructions are to build and run draupnir without using [Docker](./setup_
 You need to have installed `yarn` 1.x and Node 18.
 
 ```bash
-git clone https://github.com/gnuxie/draupnir.git
+git clone https://github.com/the-draupnir-project/Draupnir.git
 cd draupnir
 
 yarn install

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "1.85.1",
   "description": "A moderation tool for Matrix",
   "main": "lib/index.js",
-  "repository": "https://github.com/Gnuxie/Draupnir.git",
+  "repository": "https://github.com/the-draupnir-project/Draupnir.git",
   "author": "Gnuxie",
   "license": "AFL-3.0",
   "private": true,


### PR DESCRIPTION
Should be Self Explanitory what this PR Does.

I Catalan Lover agrees to contribute these commits to The Draupnir Project under the terms of the AFL-3.0 Licence as is used by the project at the time of this PR