### PR TITLE
Set `disableStores: true` in matrix-appservice-bridge BridgeOpts.

### DIFF
--- a/src/appservice/AppService.ts
+++ b/src/appservice/AppService.ts
@@ -25,7 +25,7 @@ limitations under the License.
  * are NOT distributed, contributed, committed, or licensed under the Apache License.
  */
 
-import { AppServiceRegistration, Bridge, Request, WeakEvent, BridgeContext, MatrixUser, Logger, setBridgeVersion, PrometheusMetrics } from "matrix-appservice-bridge";
+import { AppServiceRegistration, Bridge, Request, WeakEvent, MatrixUser, Logger, setBridgeVersion, PrometheusMetrics } from "matrix-appservice-bridge";
 import { MjolnirManager } from ".//MjolnirManager";
 import { DataStore } from ".//datastore";
 import { PgDataStore } from "./postgres/PgDataStore";
@@ -82,6 +82,7 @@ export class MjolnirAppService {
                 onEvent: () => { throw new Error("Mjolnir uninitialized") },
             },
             suppressEcho: false,
+            disableStores: true,
         });
         await bridge.initialise();
         const accessControlListId = await bridge.getBot().getClient().resolveRoom(config.adminRoom);
@@ -142,7 +143,7 @@ export class MjolnirAppService {
      * @param request A matrix-appservice-bridge request encapsulating a Matrix event.
      * @param context Additional context for the Matrix event.
      */
-    public async onEvent(request: Request<WeakEvent>, context: BridgeContext) {
+    public async onEvent(request: Request<WeakEvent>) {
         const mxEvent = request.getData();
         // Provision a new mjolnir for the invitee when the appservice bot (designated by this.bridge.botUserId) is invited to a room.
         // Acts as an alternative to the web api provided for the widget.
@@ -164,7 +165,7 @@ export class MjolnirAppService {
             }
         }
         this.accessControl.handleEvent(mxEvent['room_id'], mxEvent);
-        this.mjolnirManager.onEvent(request, context);
+        this.mjolnirManager.onEvent(request);
         this.commands.handleEvent(mxEvent);
     }
 

--- a/src/appservice/MjolnirManager.ts
+++ b/src/appservice/MjolnirManager.ts
@@ -1,5 +1,5 @@
 import { Mjolnir } from "../Mjolnir";
-import { Request, WeakEvent, BridgeContext, Bridge, Intent, Logger } from "matrix-appservice-bridge";
+import { Request, WeakEvent, Bridge, Intent, Logger } from "matrix-appservice-bridge";
 import { getProvisionedMjolnirConfig } from "../config";
 import PolicyList from "../models/PolicyList";
 import { MatrixClient, UserID } from "matrix-bot-sdk";
@@ -113,7 +113,7 @@ export class MjolnirManager {
     /**
      * Listener that should be setup and called by `MjolnirAppService` while listening to the bridge abstraction provided by matrix-appservice-bridge.
      */
-    public onEvent(request: Request<WeakEvent>, context: BridgeContext) {
+    public onEvent(request: Request<WeakEvent>) {
         // TODO We need a way to map a room id (that the event is from) to a set of managed mjolnirs that should be informed.
         // https://github.com/matrix-org/mjolnir/issues/412
         [...this.mjolnirs.values()].forEach((mj: ManagedMjolnir) => mj.onEvent(request));


### PR DESCRIPTION
These stores create database files all over the cwd that use nedb which shouldn't really be used by the appservice library at this point.

These files are problematic because they are undocumented to server admins trying to setup the appservice, and need to be explicitly accounted for to make permissions work.

The stores enable something called the `BridgeContext` to be given alongside the event within the `onEvent` handler. Which we don't use, and it's unclear how it should be used.

The primary motivation for removing the stores is to simplify work making the appservice available to matrix-docker-ansible-deploy.

We expect to have follow up prs to improve documentation.