### PR TITLE
Provision Draupnir instead of Mjolnir.

### DIFF
--- a/src/appservice/AppService.ts
+++ b/src/appservice/AppService.ts
@@ -209,7 +209,9 @@ export class MjolnirAppService {
         reg.setHomeserverToken(AppServiceRegistration.generateToken());
         reg.setAppServiceToken(AppServiceRegistration.generateToken());
         reg.setSenderLocalpart('draupnir-moderation');
+        // This is maintained for backwards compatibility with mjolnir4all.
         reg.addRegexPattern("users", "@mjolnir_.*", true);
+        reg.addRegexPattern("users", "@draupnir_.*", true);
         reg.setRateLimited(false);
         callback(reg);
     }

--- a/src/appservice/AppService.ts
+++ b/src/appservice/AppService.ts
@@ -208,7 +208,7 @@ export class MjolnirAppService {
         reg.setId(AppServiceRegistration.generateToken());
         reg.setHomeserverToken(AppServiceRegistration.generateToken());
         reg.setAppServiceToken(AppServiceRegistration.generateToken());
-        reg.setSenderLocalpart("mjolnir-bot");
+        reg.setSenderLocalpart('draupnir-moderation');
         reg.addRegexPattern("users", "@mjolnir_.*", true);
         reg.setRateLimited(false);
         callback(reg);

--- a/src/appservice/MjolnirManager.ts
+++ b/src/appservice/MjolnirManager.ts
@@ -131,13 +131,13 @@ export class MjolnirManager {
         }
         const provisionedMjolnirs = await this.dataStore.lookupByOwner(requestingUserId);
         if (provisionedMjolnirs.length === 0) {
-            const mjolnirLocalPart = `mjolnir_${randomUUID()}`;
+            const mjolnirLocalPart = `draupnir_${randomUUID()}`;
             const mjIntent = await this.makeMatrixIntent(mjolnirLocalPart);
 
             const managementRoomId = await mjIntent.matrixClient.createRoom({
                 preset: 'private_chat',
                 invite: [requestingUserId],
-                name: `${requestingUserId}'s mjolnir`,
+                name: `${requestingUserId}'s Draupnir`,
                 power_level_content_override: {
                     users: {
                         [requestingUserId]: 100,
@@ -158,7 +158,7 @@ export class MjolnirManager {
 
             return [mjIntent.userId, managementRoomId];
         } else {
-            throw new Error(`User: ${requestingUserId} has already provisioned ${provisionedMjolnirs.length} mjolnirs.`);
+            throw new Error(`User: ${requestingUserId} has already provisioned ${provisionedMjolnirs.length} Draupnirs.`);
         }
     }
 

--- a/src/appservice/bot/ListCommand.tsx
+++ b/src/appservice/bot/ListCommand.tsx
@@ -8,7 +8,7 @@ import { MatrixSendClient } from '../../MatrixEmitter';
 import { UnstartedMjolnir } from '../MjolnirManager';
 import { BaseFunction, defineInterfaceCommand } from '../../commands/interface-manager/InterfaceCommand';
 import { findPresentationType, parameters } from '../../commands/interface-manager/ParameterParsing';
-import { AppserviceBaseExecutor } from './AppserviceCommandHandler';
+import { AppserviceBaseExecutor, AppserviceContext } from './AppserviceCommandHandler';
 import { UserID } from 'matrix-bot-sdk';
 import { CommandError, CommandResult } from '../../commands/interface-manager/Validation';
 import { tickCrossRenderer } from '../../commands/interface-manager/MatrixHelpRenderer';
@@ -80,8 +80,8 @@ const restart = defineInterfaceCommand<AppserviceBaseExecutor>({
             description: 'The userid of the mjolnir to restart'
         }
     ]),
-    command: async (context, _keywords, mjolnirId: UserID): Promise<CommandResult<true>> => {
-        const mjolnirManager = context.appservice.mjolnirManager;
+    command: async function (this: AppserviceContext, _keywords, mjolnirId: UserID): Promise<CommandResult<true>> {
+        const mjolnirManager = this.appservice.mjolnirManager;
         const mjolnir = mjolnirManager.findUnstartedMjolnir(mjolnirId.localpart);
         if (mjolnir?.mjolnirRecord === undefined) {
             return CommandError.Result(`We can't find the unstarted mjolnir ${mjolnirId}, is it running?`);

--- a/src/appservice/postgres/PgDataStore.ts
+++ b/src/appservice/postgres/PgDataStore.ts
@@ -18,7 +18,7 @@ import { PostgresStore, SchemaUpdateFunction } from "matrix-appservice-bridge";
 import { DataStore, MjolnirRecord } from "../datastore";
 
 function getSchema(): SchemaUpdateFunction[] {
-    const nSchema = 1;
+    const nSchema = 2;
     const schema = [];
     for (let schemaID = 1; schemaID < nSchema + 1; schemaID++) {
         schema.push(require(`./schema/v${schemaID}`).runSchema);
@@ -41,7 +41,7 @@ export class PgDataStore extends PostgresStore implements DataStore {
     }
 
     public async list(): Promise<MjolnirRecord[]> {
-        const result = await this.sql`SELECT local_part, owner, management_room FROM mjolnir`;
+        const result = await this.sql`SELECT local_part, owner, management_room FROM draupnir`;
         if (!result.count) {
             return [];
         }
@@ -50,18 +50,18 @@ export class PgDataStore extends PostgresStore implements DataStore {
     }
 
     public async store(mjolnirRecord: MjolnirRecord): Promise<void> {
-        await this.sql`INSERT INTO mjolnir (local_part, owner, management_room)
+        await this.sql`INSERT INTO draupnir (local_part, owner, management_room)
         VALUES (${mjolnirRecord.local_part}, ${mjolnirRecord.owner}, ${mjolnirRecord.management_room})`;
     }
 
     public async lookupByOwner(owner: string): Promise<MjolnirRecord[]> {
-        const result = await this.sql`SELECT local_part, owner, management_room FROM mjolnir
+        const result = await this.sql`SELECT local_part, owner, management_room FROM draupnir
         WHERE owner = ${owner}`;
         return result.flat() as MjolnirRecord[];
     }
 
     public async lookupByLocalPart(localPart: string): Promise<MjolnirRecord[]> {
-        const result = await this.sql`SELECT local_part, owner, management_room FROM mjolnir
+        const result = await this.sql`SELECT local_part, owner, management_room FROM draupnir
         WHERE local_part = ${localPart}`;
         return result.flat() as MjolnirRecord[];
     }

--- a/src/appservice/postgres/schema/v2.ts
+++ b/src/appservice/postgres/schema/v2.ts
@@ -1,0 +1,8 @@
+
+import postgres from 'postgres';
+
+export async function runSchema(sql: postgres.Sql) {
+    await sql.begin(s => [
+        s`ALTER TABLE IF EXISTS mjolnir RENAME TO draupnir;`
+    ]);
+}


### PR DESCRIPTION
The appservice still uses the mjolnir4all naming for provisioned mjolnir.
This upstreams https://github.com/the-draupnir-project/Draupnir/commit/d5e25505a20f222ee1cd9c2076d6b532e9bf6728 with a couple of other basic fixes. 