### PR TITLE
Change dependabot interval to monthly + group production deps too.

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,15 +3,17 @@ updates:
   - package-ecosystem: "npm"
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
     groups:
       development-dependencies:
         dependency-type: "development"
+      production-dependencies:
+        dependency-type: "production"
 
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
     groups:
       github-actions:
         patterns:


### PR DESCRIPTION
Too much maintnence burden to review weekly... and we may aswell just review all the production deps at the same time so we can checkout the branch and just fix things that are broken.