### PR TITLE
Experimental new joiner protection.

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -80,6 +80,10 @@ export interface IConfig {
       words: string[];
       minutesBeforeTrusting: number;
     };
+    newJoinerProtection: {
+      serverNames: string[];
+      banMessage: string;
+    };
   };
   health: {
     healthz: {
@@ -168,6 +172,11 @@ const defaultConfig: IConfig = {
     wordlist: {
       words: [],
       minutesBeforeTrusting: 20,
+    },
+    newJoinerProtection: {
+      serverNames: [],
+      banMessage:
+        "Unfortunately we cannot accept new users from your homeserver at this time.",
     },
   },
   health: {

--- a/src/protections/DraupnirProtectionsIndex.ts
+++ b/src/protections/DraupnirProtectionsIndex.ts
@@ -16,6 +16,7 @@ import "./JoinWaveShortCircuit";
 import "./RedactionSynchronisation";
 import "./MessageIsMedia";
 import "./MessageIsVoice";
+import "./NewJoinerProtection";
 import "./PolicyChangeNotification";
 import "./TrustedReporters";
 import "./WordList";

--- a/src/protections/NewJoinerProtection.ts
+++ b/src/protections/NewJoinerProtection.ts
@@ -88,7 +88,8 @@ export type NewJoinerProtectionCapabilities = {
 describeProtection<NewJoinerProtectionCapabilities, Draupnir>({
   name: "NewJoinerProtection",
   description: `Highly experimental protection that will ban all new joiners from configured homeservers.
-    Will not ban existing users from those servers, and unbanning users will allow them to join normally.`,
+    Will not ban existing users from those servers, and unbanning users will allow them to join normally.
+    Please read the documentation https://the-draupnir-project.github.io/draupnir-documentation/protections/new-joiner-protection.`,
   capabilityInterfaces: {
     userConsequences: "UserConsequences",
   },

--- a/src/protections/NewJoinerProtection.ts
+++ b/src/protections/NewJoinerProtection.ts
@@ -1,0 +1,107 @@
+// Copyright 2024 Gnuxie <Gnuxie@protonmail.com>
+//
+// SPDX-License-Identifier: AFL-3.0
+
+import {
+  AbstractProtection,
+  ActionError,
+  ActionResult,
+  MembershipChange,
+  MembershipChangeType,
+  MultipleErrors,
+  Ok,
+  ProtectedRoomsSet,
+  Protection,
+  ProtectionDescription,
+  RoomMembershipRevision,
+  UnknownSettings,
+  UserConsequences,
+  describeProtection,
+  isError,
+  serverName,
+} from "matrix-protection-suite";
+import { Draupnir } from "../Draupnir";
+import { IConfig } from "../config";
+
+export type NewJoinerProtectionDescription = ProtectionDescription<
+  unknown,
+  UnknownSettings<string>,
+  NewJoinerProtectionCapabilities
+>;
+
+export class NewJoinerProtection
+  extends AbstractProtection<NewJoinerProtectionDescription>
+  implements Protection<NewJoinerProtectionDescription>
+{
+  private readonly userConsequences: UserConsequences;
+  private readonly bannedServers: Set<string>;
+  private readonly banReason: string;
+  constructor(
+    description: NewJoinerProtectionDescription,
+    capabilities: NewJoinerProtectionCapabilities,
+    protectedRoomsSet: ProtectedRoomsSet,
+    draupnirConfig: IConfig
+  ) {
+    super(description, capabilities, protectedRoomsSet, {});
+    this.userConsequences = capabilities.userConsequences;
+    this.bannedServers = new Set(
+      draupnirConfig.protections.newJoinerProtection.serverNames
+    );
+    this.banReason = draupnirConfig.protections.newJoinerProtection.banMessage;
+  }
+
+  public async handleMembershipChange(
+    revision: RoomMembershipRevision,
+    changes: MembershipChange[]
+  ): Promise<ActionResult<void>> {
+    const errors: ActionError[] = [];
+    for (const change of changes) {
+      if (change.membershipChangeType === MembershipChangeType.Joined) {
+        if (this.bannedServers.has(serverName(change.userID))) {
+          const banResult =
+            await this.userConsequences.consequenceForUserInRoom(
+              revision.room.toRoomIDOrAlias(),
+              change.userID,
+              this.banReason
+            );
+          if (isError(banResult)) {
+            errors.push(banResult.error);
+          }
+        }
+      }
+    }
+    if (errors.length === 0) {
+      return Ok(undefined);
+    } else {
+      return MultipleErrors.Result(
+        `There were errors when banning members in ${revision.room.toPermalink()}`,
+        { errors }
+      );
+    }
+  }
+}
+
+export type NewJoinerProtectionCapabilities = {
+  userConsequences: UserConsequences;
+};
+
+describeProtection<NewJoinerProtectionCapabilities, Draupnir>({
+  name: "NewJoinerProtection",
+  description: `Highly experimental protection that will ban all new joiners from configured homeservers.
+    Will not ban existing users from those servers, and unbanning users will allow them to join normally.`,
+  capabilityInterfaces: {
+    userConsequences: "UserConsequences",
+  },
+  defaultCapabilities: {
+    userConsequences: "StandardUserConsequences",
+  },
+  factory: (decription, protectedRoomsSet, draupnir, capabilitySet) =>
+    Ok(
+      new NewJoinerProtection(
+        decription,
+        capabilitySet,
+        protectedRoomsSet,
+        draupnir.config
+      )
+    ),
+});


### PR DESCRIPTION
This protection allows room moderators to ban new users from servers (matrix.org). Existing users will be able to participate normally, and if they are accidentally banned, once unbanned rejoining will be unaffected.

This is intended to be used during periods of instability. The protection may be removed entirely or modified in a future release. We will add a documentation page shortly. 