### PR TITLE
StandardEventConsequencesRenderer was named wrong.

### DIFF
--- a/src/capabilities/StandardEventConsequencesRenderer.tsx
+++ b/src/capabilities/StandardEventConsequencesRenderer.tsx
@@ -71,7 +71,7 @@ class StandardEventConsequencesRenderer implements EventConsequences {
 }
 
 describeCapabilityRenderer<EventConsequences, Draupnir>({
-  name: "StandardEventConsequencesRenderer",
+  name: "StandardEventConsequences",
   description: "Renders the standard event consequences capability",
   interface: "EventConsequences",
   factory(description, draupnir, capability) {
@@ -84,7 +84,7 @@ describeCapabilityRenderer<EventConsequences, Draupnir>({
 });
 
 describeCapabilityContextGlue<Draupnir, { eventRedacter: RoomEventRedacter }>({
-  name: "StandardEventConsequencesRenderer",
+  name: "StandardEventConsequences",
   glueMethod: function (
     protectionDescription,
     draupnir,


### PR DESCRIPTION
The name of the renderer needs to match the name of the associated capability. Otherwise when a protection asks for the capability you will get an obscure error about not being able to find a renderer for the cap.  