### PR TITLE
Give MatrixInterfaceAdaptor all of its required callbacks.

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "@sentry/node": "^7.17.2",
     "@sentry/tracing": "^7.17.2",
     "@sinclair/typebox": "0.32.34",
-    "@the-draupnir-project/interface-manager": "1.1.1",
+    "@the-draupnir-project/interface-manager": "2.0.0",
     "@the-draupnir-project/matrix-basic-types": "^0.1.1",
     "await-lock": "^2.2.2",
     "better-sqlite3": "^9.4.3",

--- a/src/appservice/bot/AppserviceBotCommandDispatcher.ts
+++ b/src/appservice/bot/AppserviceBotCommandDispatcher.ts
@@ -19,17 +19,11 @@ import {
 } from "@the-draupnir-project/interface-manager";
 import {
   MPSCommandDispatcherCallbacks,
+  MPSMatrixInterfaceAdaptorCallbacks,
   MatrixEventContext,
   invocationInformationFromMatrixEventcontext,
-  matrixEventsFromDeadDocument,
-  rendererFailedCB,
 } from "../../commands/interface-manager/MPSMatrixInterfaceAdaptor";
 import { AppserviceAdaptorContext } from "./AppserviceBotPrerequisite";
-import {
-  promptDefault,
-  promptSuggestions,
-} from "../../commands/interface-manager/MatrixPromptForAccept";
-import { matrixCommandRenderer } from "../../commands/interface-manager/MatrixHelpRenderer";
 import { userLocalpart } from "@the-draupnir-project/matrix-basic-types";
 import { AppserviceBotCommands } from "./AppserviceBotCommandTable";
 import { AppserviceBotHelpCommand } from "./AppserviceBotHelp";
@@ -43,11 +37,8 @@ export const AppserviceBotInterfaceAdaptor = new StandardMatrixInterfaceAdaptor<
 >(
   AppserviceAdaptorContextToCommandContextTranslator,
   invocationInformationFromMatrixEventcontext,
-  promptDefault,
-  promptSuggestions,
-  matrixCommandRenderer,
-  matrixEventsFromDeadDocument,
-  rendererFailedCB
+  MPSMatrixInterfaceAdaptorCallbacks,
+  MPSCommandDispatcherCallbacks
 );
 
 function makePrefixExtractor(

--- a/src/commands/DraupnirCommandPrerequisites.ts
+++ b/src/commands/DraupnirCommandPrerequisites.ts
@@ -13,16 +13,11 @@ import {
 } from "@the-draupnir-project/interface-manager";
 import { Draupnir } from "../Draupnir";
 import {
+  MPSCommandDispatcherCallbacks,
+  MPSMatrixInterfaceAdaptorCallbacks,
   MatrixEventContext,
   invocationInformationFromMatrixEventcontext,
-  matrixEventsFromDeadDocument,
-  rendererFailedCB,
 } from "./interface-manager/MPSMatrixInterfaceAdaptor";
-import { matrixCommandRenderer } from "./interface-manager/MatrixHelpRenderer";
-import {
-  promptDefault,
-  promptSuggestions,
-} from "./interface-manager/MatrixPromptForAccept";
 
 export const DraupnirContextToCommandContextTranslator =
   new StandardAdaptorContextToCommandContextTranslator<Draupnir>();
@@ -32,9 +27,6 @@ export const DraupnirInterfaceAdaptor = new StandardMatrixInterfaceAdaptor<
 >(
   DraupnirContextToCommandContextTranslator,
   invocationInformationFromMatrixEventcontext,
-  promptDefault,
-  promptSuggestions,
-  matrixCommandRenderer,
-  matrixEventsFromDeadDocument,
-  rendererFailedCB
+  MPSMatrixInterfaceAdaptorCallbacks,
+  MPSCommandDispatcherCallbacks
 );

--- a/src/commands/interface-manager/MPSMatrixInterfaceAdaptor.ts
+++ b/src/commands/interface-manager/MPSMatrixInterfaceAdaptor.ts
@@ -30,6 +30,7 @@ import {
   CommandDispatcherCallbacks,
   DocumentNode,
   InvocationInformationFromEventContext,
+  MatrixInterfaceAdaptorCallbacks,
   MatrixInterfaceEventsFromDeadDocument,
   MatrixInterfaceRendererFailedCB,
   StandardAdaptorContextToCommandContextTranslator,
@@ -175,7 +176,7 @@ export const MPSCommandDispatcherCallbacks = {
     return new ActionException(
       ActionExceptionKind.Unknown,
       error,
-      "An unexpected error occurred while processing the command."
+      error.message
     );
   },
 } satisfies CommandDispatcherCallbacks<BasicInvocationInformation>;
@@ -189,6 +190,17 @@ export const rendererFailedCB: MatrixInterfaceRendererFailedCB<
     rendererError
   );
 };
+
+export const MPSMatrixInterfaceAdaptorCallbacks = Object.freeze({
+  promptDefault,
+  promptSuggestions,
+  defaultRenderer: matrixCommandRenderer,
+  matrixEventsFromDeadDocument,
+  rendererFailedCB,
+}) satisfies MatrixInterfaceAdaptorCallbacks<
+  MatrixAdaptorContext,
+  MatrixEventContext
+>;
 
 export const invocationInformationFromMatrixEventcontext: InvocationInformationFromEventContext<MatrixEventContext> =
   function (eventContext) {
@@ -207,9 +219,6 @@ export const MPSMatrixInterfaceAdaptor = new StandardMatrixInterfaceAdaptor<
 >(
   MPSContextToCommandContextTranslator,
   invocationInformationFromMatrixEventcontext,
-  promptDefault,
-  promptSuggestions,
-  matrixCommandRenderer,
-  matrixEventsFromDeadDocument,
-  rendererFailedCB
+  MPSMatrixInterfaceAdaptorCallbacks,
+  MPSCommandDispatcherCallbacks
 );

--- a/yarn.lock
+++ b/yarn.lock
@@ -256,10 +256,10 @@
   resolved "https://registry.yarnpkg.com/@sinclair/typebox/-/typebox-0.27.8.tgz#6667fac16c436b5434a387a34dedb013198f6e6e"
   integrity sha512-+Fj43pSMwJs4KRrH/938Uf+uAELIgVBmQzg/q1YG10djyfA3TnrU8N8XzqCh/okZdszqBQTZf96idMfE5lnwTA==
 
-"@the-draupnir-project/interface-manager@1.1.1":
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/@the-draupnir-project/interface-manager/-/interface-manager-1.1.1.tgz#065201a1554cb6e2a4bdd20eb04da1feb413bc53"
-  integrity sha512-83U5y9u77sAW2bLWmtDBzhAjX3Rbcle7xkQ86ee6sJKjevrjTf7FIqf2CAV1uic1JcQUCJDvfORPPpfNqEqjfw==
+"@the-draupnir-project/interface-manager@2.0.0":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@the-draupnir-project/interface-manager/-/interface-manager-2.0.0.tgz#1386bb7d59257d867f963adf600cc506f3ec591d"
+  integrity sha512-DD3D3cOx0LqPJ4oET1+ttpUlVZf+4u8RTqFwxL0Qh8KOWLS9oxBwiw+U0IPDbTa+07hbhzY/hRMRBiqheXS/LQ==
   dependencies:
     "@gnuxie/super-cool-stream" "^0.2.1"
     "@gnuxie/typescript-result" "^0.2.0"


### PR DESCRIPTION
The interface has been changed in `interface-manager` so that we can't forget them. 

Means that our little error renderer works again.
![image](https://github.com/user-attachments/assets/23dddf7f-2dfb-4a71-85a6-554dbf85982e)
