### PR TITLE
Enable `strictPropertyInitialization` in tsconfig.json.

### DIFF
--- a/src/Draupnir.ts
+++ b/src/Draupnir.ts
@@ -130,6 +130,10 @@ export class Draupnir implements Client, MatrixAdaptorContext {
       this.client,
       this.config
     );
+    this.taskQueue = new ThrottlingQueue(
+      this.managementRoomOutput,
+      config.backgroundDelayMS
+    );
     this.reactionHandler = new MatrixReactionHandler(
       this.managementRoom.toRoomIDOrAlias(),
       client,

--- a/src/health/healthz.ts
+++ b/src/health/healthz.ts
@@ -16,7 +16,9 @@ import { IConfig } from "../config";
 export class Healthz {
   private healthCode: number;
 
-  constructor(private config: IConfig) {}
+  constructor(private config: IConfig) {
+    this.healthCode = this.config.health.healthz.unhealthyStatus;
+  }
 
   public set isHealthy(val: boolean) {
     this.healthCode = val

--- a/src/protections/BasicFlooding.ts
+++ b/src/protections/BasicFlooding.ts
@@ -163,6 +163,7 @@ export class BasicFloodingProtection
   ) {
     super(description, capabilities, protectedRoomsSet, {});
     this.userConsequences = capabilities.userConsequences;
+    this.eventConsequences = capabilities.eventConsequences;
   }
 
   public async handleTimelineEvent(

--- a/src/protections/MessageIsVoice.ts
+++ b/src/protections/MessageIsVoice.ts
@@ -12,7 +12,6 @@ import { LogLevel } from "matrix-bot-sdk";
 import {
   AbstractProtection,
   ActionResult,
-  CapabilitySet,
   EventConsequences,
   Ok,
   ProtectedRoomsSet,
@@ -80,11 +79,12 @@ export class MessageIsVoiceProtection
   private readonly eventConsequences: EventConsequences;
   constructor(
     description: MessageIsVoiceDescription,
-    capabilities: CapabilitySet,
+    capabilities: MessageIsVoiceCapabilities,
     protectedRoomsSet: ProtectedRoomsSet,
     private readonly draupnir: Draupnir
   ) {
     super(description, capabilities, protectedRoomsSet, {});
+    this.eventConsequences = capabilities.eventConsequences;
   }
 
   public async handleTimelineEvent(

--- a/src/queues/ThrottlingQueue.ts
+++ b/src/queues/ThrottlingQueue.ts
@@ -28,12 +28,6 @@ export class ThrottlingQueue {
   private timeout: ReturnType<typeof setTimeout> | null;
 
   /**
-   * How long we should wait between the completion of a tasks and the start of the next task.
-   * Any >=0 number is good.
-   */
-  private _delayMS: number;
-
-  /**
    * Construct an empty queue.
    *
    * This queue will start executing whenever `push()` is called and stop
@@ -43,7 +37,11 @@ export class ThrottlingQueue {
    */
   constructor(
     private managementRoomOutput: ManagementRoomOutput,
-    delayMS: number
+    /**
+     * How long we should wait between the completion of a tasks and the start of the next task.
+     * Any >=0 number is good.
+     */
+    private delayMS: number
   ) {
     this.timeout = null;
     this.delayMS = delayMS;
@@ -125,7 +123,7 @@ export class ThrottlingQueue {
     }
     this.timeout = setTimeout(() => {
       void this.step();
-    }, this._delayMS);
+    }, this.delayMS);
   }
 
   /**
@@ -148,20 +146,13 @@ export class ThrottlingQueue {
    *
    * This will be used next time a task is completed.
    */
-  set delayMS(delayMS: number) {
+  public setDelayMS(delayMS: number) {
     if (delayMS < 0) {
       throw new TypeError(
         `Invalid delay ${delayMS}. Need a non-negative number of ms.`
       );
     }
-    this._delayMS = delayMS;
-  }
-
-  /**
-   * Return the delay between completion of an event and the start of the next event.
-   */
-  get delayMS(): number {
-    return this._delayMS;
+    this.delayMS = delayMS;
   }
 
   /**

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,30 +1,26 @@
 {
-    "compilerOptions": {
-        "alwaysStrict": true,
-        "esModuleInterop": true,
-        "exactOptionalPropertyTypes": true,
-        "experimentalDecorators": true,
-        "emitDecoratorMetadata": true,
-        "module": "commonjs",
-        "moduleResolution": "node",
-        "newLine": "LF",
-        "noImplicitAny": true,
-        "noImplicitReturns": true,
-        "noImplicitThis": true,
-        "noUncheckedIndexedAccess": true,
-        "noUnusedLocals": true,
-        "outDir": "./lib",
-        "sourceMap": true,
-        "strictNullChecks": true,
-        "target": "es2021",
-        "types": [
-            "node",
-            "mocha"
-        ],
-        "jsx": "react",
-        "jsxFactory": "DeadDocumentJSX.JSXFactory"
-    },
-    "include": [
-        "./src/**/*"
-    ],
+  "compilerOptions": {
+    "alwaysStrict": true,
+    "esModuleInterop": true,
+    "exactOptionalPropertyTypes": true,
+    "experimentalDecorators": true,
+    "emitDecoratorMetadata": true,
+    "module": "commonjs",
+    "moduleResolution": "node",
+    "newLine": "LF",
+    "noImplicitAny": true,
+    "noImplicitReturns": true,
+    "noImplicitThis": true,
+    "noUncheckedIndexedAccess": true,
+    "noUnusedLocals": true,
+    "outDir": "./lib",
+    "sourceMap": true,
+    "strictNullChecks": true,
+    "strictPropertyInitialization": true,
+    "target": "es2021",
+    "types": ["node", "mocha"],
+    "jsx": "react",
+    "jsxFactory": "DeadDocumentJSX.JSXFactory"
+  },
+  "include": ["./src/**/*"]
 }


### PR DESCRIPTION
This will stop situations where the throttling queue was uninitialized in the Draupnir instances.

We should really enable `strict` for typescript.

The blocker for that is `useUnknownInCatchVariables` around legacy code (which should be minor).
And also `strictFunctionTypes`, which `interface-manager` exacerbates by not providing the right generics for `describeRenderer` and other methods. 

https://github.com/the-draupnir-project/Draupnir/issues/496