### PR TITLE
Kick command wtf moment

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "remove-tests-from-lib": "rm -rf lib/test/ && cp -r lib/src/* lib/ && rm -rf lib/src/",
     "lint": "corepack yarn eslint src test && corepack yarn prettier --check src test",
     "start:dev": "corepack yarn build && node --async-stack-traces lib/index.js",
-    "test:unit": "mocha --require './test/tsnode.cjs' 'test/unit/**/*.{ts,tsx}'",
+    "test:unit": "mocha --require './test/tsnode.cjs' --forbid-only 'test/unit/**/*.{ts,tsx}'",
     "test:unit:single": "mocha --require test/tsnode.cjs",
     "test:integration": "NODE_ENV=harness mocha --require test/tsnode.cjs --async-stack-traces --forbid-only --require test/integration/fixtures.ts --timeout 300000 --project ./tsconfig.json \"test/integration/**/*Test.ts\"",
     "test:integration:single": "NODE_ENV=harness corepack yarn mocha --require test/tsnode.cjs --require test/integration/fixtures.ts --timeout 300000 --project ./tsconfig.json",

--- a/src/commands/KickCommand.tsx
+++ b/src/commands/KickCommand.tsx
@@ -163,15 +163,15 @@ export const DraupnirKickCommand = describeCommand({
             revision.room.toRoomIDOrAlias(),
             member.userID
           );
-        }
-        if (!isDryRun) {
-          taskQueue.push(() => {
-            return roomKicker.kickUser(
-              revision.room.toRoomIDOrAlias(),
-              member.userID,
-              reason
-            );
-          });
+          if (!isDryRun) {
+            taskQueue.push(() => {
+              return roomKicker.kickUser(
+                revision.room.toRoomIDOrAlias(),
+                member.userID,
+                reason
+              );
+            });
+          }
         }
       }
     }

--- a/src/commands/KickCommand.tsx
+++ b/src/commands/KickCommand.tsx
@@ -165,7 +165,7 @@ export const DraupnirKickCommand = describeCommand({
           );
         }
         if (!isDryRun) {
-          void taskQueue.push(async () => {
+          taskQueue.push(() => {
             return roomKicker.kickUser(
               revision.room.toRoomIDOrAlias(),
               member.userID,

--- a/test/tsnode.cjs
+++ b/test/tsnode.cjs
@@ -9,3 +9,8 @@ require("ts-node").register({
     before: [tsAutoMockTransformer(program)],
   }),
 });
+
+// Mocha apparently suppresses unhandled rejections for some crazy reason??
+process.on("unhandledRejection", (reason) => {
+  throw reason;
+});

--- a/test/unit/commands/KickCommandTest.ts
+++ b/test/unit/commands/KickCommandTest.ts
@@ -10,6 +10,7 @@ import {
   userServerName,
 } from "@the-draupnir-project/matrix-basic-types";
 import {
+  Logger,
   Membership,
   Ok,
   RoomKicker,
@@ -22,6 +23,8 @@ import { ThrottlingQueue } from "../../../src/queues/ThrottlingQueue";
 import ManagementRoomOutput from "../../../src/ManagementRoomOutput";
 import { createMock } from "ts-auto-mock";
 import expect from "expect";
+
+const log = new Logger("KickCommandTest");
 
 async function createProtectedRooms() {
   return await describeProtectedRoomsSet({
@@ -48,7 +51,13 @@ async function createProtectedRooms() {
   });
 }
 
-const taskQueue = new ThrottlingQueue(createMock<ManagementRoomOutput>(), 0);
+const managmenetRoomOutput = createMock<ManagementRoomOutput>({
+  logMessage(_level, module, message, _additionalRoomIds, _isRecursive) {
+    log.error(module, message);
+    throw new TypeError(`We don't expect to be logging anything`);
+  },
+});
+const taskQueue = new ThrottlingQueue(managmenetRoomOutput, 0);
 
 describe("Test the KickCommand", function () {
   const roomResolver = createMock<RoomResolver>({


### PR DESCRIPTION
disbelief, but basically Mocha is an asshole and was suppressing uncaught promise rejections, and then the throttling queue was catching errors in kick command unit test. So between them the test for glob kicks looked like it was passing, when it was actually causing an assertion failure that we couldn't see. And this meant that we couldn't tell that glob kicks were always banning everyone and everything no matter what. This seems to effect all `v2.0.0-beta.*` releases, but I don't think there is a release where the kick command will actually run without some other error happening first. 