### PR TITLE
Start draupnir bots in batches when running in appservice mode

### DIFF
--- a/src/appservice/AppServiceDraupnirManager.ts
+++ b/src/appservice/AppServiceDraupnirManager.ts
@@ -372,49 +372,23 @@ export class AppServiceDraupnirManager {
     }
   }
 
-  /**
-   * Makes chunks for the startup of the bot
-   * @param chunk_size The size each chunk will be
-   * @param iter The data that should be split into chunks
-   */
-  private *chunked(chunk_size: number, iter: MjolnirRecord[]) {
-    let r = [];
-    for (const x of iter) {
-      r.push(x);
-      if (r.length === chunk_size) {
-        yield r;
-        r = [];
-      }
-    }
-    if (r.length) yield r;
-  }
-
   // TODO: We need to check that an owner still has access to the appservice each time they send a command to the mjolnir or use the web api.
   // https://github.com/matrix-org/mjolnir/issues/410
   /**
    * Used at startup to create all the ManagedMjolnir instances and start them so that they will respond to users.
    */
   public async startDraupnirs(mjolnirRecords: MjolnirRecord[]): Promise<void> {
-    // Start the bots in small parrallel batches instead of sequentially.
+    // Start the bots in small batches instead of sequentially.
     // This is to avoid a thundering herd of bots all starting at once.
     // It also is to avoid that others have to wait for a single bot to start.
-
-    const batchSize = 5;
-    const batches: MjolnirRecord[][] = [
-      ...this.chunked(batchSize, mjolnirRecords),
-    ];
-
-    // Start each batch in parallel.
-    await Promise.allSettled(
-      batches.map(async (batch) => {
-        // Start each mjolnir in the batch in parallel.
-        await Promise.allSettled(
-          batch.map(async (mjolnirRecord) => {
-            await this.startDraupnirFromRecord(mjolnirRecord);
-          })
-        );
-      })
-    );
+    const chunkSize = 5;
+    for (let i = 0; i < mjolnirRecords.length; i += chunkSize) {
+      const batch = mjolnirRecords.slice(i, i + chunkSize);
+      await Promise.all(
+        // `startDraupnirFromRecord` handles errors for us and adds the draupnir to the list of unstarted draupnir.
+        batch.map((record) => this.startDraupnirFromRecord(record))
+      );
+    }
   }
 }
 


### PR DESCRIPTION
This upstreams https://github.com/the-draupnir-project/Draupnir/blob/9a4f48c31e2289a2c4db308fd6f5d60c3a61fda4/src/appservice/MjolnirManager.ts#L237-L276 from my d4all branch. Idk if this is a too big or small chunk size but it seems to work in prod. Its a generator simply because it was giving a convenient iterator api to use. Though technically I am not making much use of it. So not sure if it should be like this but in the end its also not bad as a generator so idk.