### PR TITLE
Use multi-stage build in Dockerfile

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -2,7 +2,6 @@
 #
 # SPDX-License-Identifier: CC0-1.0
 
-.git
 node_modules
 config
 lib

--- a/.github/workflows/docker-hub-develop.yml
+++ b/.github/workflows/docker-hub-develop.yml
@@ -30,8 +30,6 @@ jobs:
         uses: actions/checkout@v4
       - name: Unshallow for git describe so we can create version.txt
         run: git fetch --prune --unshallow --tags --all --force
-      - name: Prepare version file
-        run: git describe > version.txt
 
       # Needed for multi platform builds
       - name: Set up QEMU

--- a/.github/workflows/docker-hub-latest.yml
+++ b/.github/workflows/docker-hub-latest.yml
@@ -30,9 +30,6 @@ jobs:
         run: echo "RELEASE_VERSION=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
       - name: Unshallow for git describe so we can create version.txt
         run: git fetch --prune --unshallow --tags --all --force
-      - name: Prepare version file
-        run: git describe > version.txt
-
       # Needed for multi platform builds
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3

--- a/.github/workflows/docker-hub-release.yml
+++ b/.github/workflows/docker-hub-release.yml
@@ -30,8 +30,6 @@ jobs:
         run: echo "RELEASE_VERSION=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
       - name: Unshallow for git describe so we can create version.txt
         run: git fetch --prune --unshallow --tags --all --force
-      - name: Prepare version file
-        run: git describe > version.txt
 
       # Needed for multi platform builds
       - name: Set up QEMU

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ RUN cd /tmp/src \
     && yarn install --frozen-lockfile --production --network-timeout 100000
 
 FROM node:20-slim as final-stage
-COPY --from=git-stamp-stage /tmp/src/version.txt version.txt
+COPY --from=build-stage /tmp/src/version.txt version.txt
 COPY --from=build-stage /tmp/src/lib/ /draupnir/
 COPY --from=build-stage /tmp/src/node_modules /node_modules
 COPY --from=build-stage /tmp/src/draupnir-entrypoint.sh /

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,13 +3,12 @@
 #
 # SPDX-License-Identifier: Apache-2.0 AND AFL-3.0
 
-FROM alpine/git:latest as git-stamp-stage
-COPY . /tmp/src
-RUN cd /tmp/src && git describe > version.txt.tmp && mv version.txt.tmp version.txt
-
 FROM node:20-slim as build-stage
+RUN apt-get update && apt-get install -y git && rm -rf /var/lib/apt/lists/*
 COPY . /tmp/src
-COPY --from=git-stamp-stage /tmp/src/version.txt version.txt
+# describe the version.
+RUN cd /tmp/src && git describe > version.txt.tmp && mv version.txt.tmp version.txt
+# build and install
 RUN cd /tmp/src \
     && yarn install --frozen-lockfile --network-timeout 100000 \
     && yarn build \

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,19 +3,24 @@
 #
 # SPDX-License-Identifier: Apache-2.0 AND AFL-3.0
 
-# We can't use alpine anymore because crypto has rust deps.
-FROM node:20-slim
+FROM alpine/git:latest as git-stamp-stage
 COPY . /tmp/src
+RUN cd /tmp/src && git describe > version.txt.tmp && mv version.txt.tmp version.txt
+
+FROM node:20-slim as build-stage
+COPY . /tmp/src
+COPY --from=git-stamp-stage /tmp/src/version.txt version.txt
 RUN cd /tmp/src \
-    && yarn install --network-timeout 100000 \
+    && yarn install --frozen-lockfile --network-timeout 100000 \
     && yarn build \
-    && mv lib/ /draupnir/ \
-    && mv node_modules / \
-    && mv draupnir-entrypoint.sh / \
-    && mv package.json / \
-    && mv version.txt / \
-    && cd / \
-    && rm -rf /tmp/*
+    && yarn install --frozen-lockfile --production --network-timeout 100000
+
+FROM node:20-slim as final-stage
+COPY --from=git-stamp-stage /tmp/src/version.txt version.txt
+COPY --from=build-stage /tmp/src/lib/ /draupnir/
+COPY --from=build-stage /tmp/src/node_modules /node_modules
+COPY --from=build-stage /tmp/src/draupnir-entrypoint.sh /
+COPY --from=build-stage /tmp/src/package.json /
 
 ENV NODE_ENV=production
 ENV NODE_CONFIG_DIR=/data/config


### PR DESCRIPTION
Fixes https://github.com/the-draupnir-project/Draupnir/issues/300

I also tried to use alpine again but rust-crypto is still fucky

with `gcompat`:
```
/node_modules/@matrix-org/matrix-sdk-crypto-nodejs/index.js:250
    throw loadError
    ^

Error: Error relocating /node_modules/@matrix-org/matrix-sdk-crypto-nodejs/matrix-sdk-crypto.linux-x64-musl.node: __register_atfork: symbol not found
    at Module._extensions..node (node:internal/modules/cjs/loader:1586:18)
    at Module.load (node:internal/modules/cjs/loader:1288:32)
    at Module._load (node:internal/modules/cjs/loader:1104:12)
    at Module.require (node:internal/modules/cjs/loader:1311:19)
    at require (node:internal/modules/helpers:179:18)
    at Object.<anonymous> (/node_modules/@matrix-org/matrix-sdk-crypto-nodejs/index.js:175:31)
    at Module._compile (node:internal/modules/cjs/loader:1469:14)
    at Module._extensions..js (node:internal/modules/cjs/loader:1548:10)
    at Module.load (node:internal/modules/cjs/loader:1288:32)
    at Module._load (node:internal/modules/cjs/loader:1104:12) {
  code: 'ERR_DLOPEN_FAILED'
}

```

without `gcompat`:

```
/node_modules/@matrix-org/matrix-sdk-crypto-nodejs/index.js:250
    throw loadError
    ^

Error: Error loading shared library ld-linux-x86-64.so.2: No such file or directory (needed by /node_modules/@matrix-org/matrix-sdk-crypto-nodejs/matrix-sdk-crypto.linux-x64-musl.node)
    at Module._extensions..node (node:internal/modules/cjs/loader:1586:18)
    at Module.load (node:internal/modules/cjs/loader:1288:32)
    at Module._load (node:internal/modules/cjs/loader:1104:12)
    at Module.require (node:internal/modules/cjs/loader:1311:19)
    at require (node:internal/modules/helpers:179:18)
    at Object.<anonymous> (/node_modules/@matrix-org/matrix-sdk-crypto-nodejs/index.js:175:31)
    at Module._compile (node:internal/modules/cjs/loader:1469:14)
    at Module._extensions..js (node:internal/modules/cjs/loader:1548:10)
    at Module.load (node:internal/modules/cjs/loader:1288:32)
    at Module._load (node:internal/modules/cjs/loader:1104:12) {
  code: 'ERR_DLOPEN_FAILED'
}
```

Testing was done locally by using `docker run --rm -it --network=host -v "/home/user/experiments/Draupnir/test/harness/mjolnir-data:/data" --name=draupnir draupnir-multi-stage bot --draupnir-config /data/config/production.yaml`