### PR TITLE
Fix `pre-commit run --all-files`, add check for executables and shebangs

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,7 +10,7 @@ ci:
   skip: [yarn-lint]
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.6.0
+    rev: v5.0.0
     hooks:
       - id: trailing-whitespace
         args: ["--markdown-linebreak-ext", "md"]
@@ -19,7 +19,7 @@ repos:
       - id: check-yaml
       - id: check-added-large-files
   - repo: https://github.com/editorconfig-checker/editorconfig-checker.python
-    rev: "2.7.3"
+    rev: "3.0.3"
     hooks:
       - id: editorconfig-checker
         alias: ec
@@ -34,7 +34,7 @@ repos:
         entry: corepack yarn lint --cache --quiet
         language: system
   - repo: https://github.com/python-jsonschema/check-jsonschema
-    rev: 0.29.2
+    rev: 0.29.3
     hooks:
       - id: check-renovate
         additional_dependencies: ["pyjson5"]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -34,7 +34,7 @@ repos:
     hooks:
       - id: yarn-lint
         name: linter
-        entry: corepack yarn lint --cache --quiet
+        entry: corepack yarn lint
         language: system
   - repo: https://github.com/python-jsonschema/check-jsonschema
     rev: 0.29.3

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,6 +20,7 @@ repos:
       - id: check-added-large-files
       - id: check-executables-have-shebangs
       - id: check-shebang-scripts-are-executable
+      - id: check-illegal-windows-names
   - repo: https://github.com/editorconfig-checker/editorconfig-checker.python
     rev: "3.0.3"
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,6 +18,8 @@ repos:
       - id: end-of-file-fixer
       - id: check-yaml
       - id: check-added-large-files
+      - id: check-executables-have-shebangs
+      - id: check-shebang-scripts-are-executable
   - repo: https://github.com/editorconfig-checker/editorconfig-checker.python
     rev: "3.0.3"
     hooks:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,15 +15,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-* `Dockerfile`: entry-point was renamed from `mjolnir-entrypoint.sh` to `draupnir-entrypoint.sh`.
-If you have built a Dockerfile based on ours, you may need to make some changes.
+- `Dockerfile`: entry-point was renamed from `mjolnir-entrypoint.sh` to `draupnir-entrypoint.sh`.
+  If you have built a Dockerfile based on ours, you may need to make some changes.
 
-* `Dockerfile`: source code was moved from `/mjolnir` to `/draupnir`. If you have built a custom
-docker image based on our Dockerfile based on ours, you may need to make some changes.
+- `Dockerfile`: source code was moved from `/mjolnir` to `/draupnir`. If you have built a custom
+  docker image based on our Dockerfile based on ours, you may need to make some changes.
 
-* The appservice registration file generator no longer emits `mjolnir-registration.yaml`
-as it has been renamed to `draupnir-registration.yaml`. This is only a concern if you have
-automated tooling that generates a registration file.
+- The appservice registration file generator no longer emits `mjolnir-registration.yaml`
+  as it has been renamed to `draupnir-registration.yaml`. This is only a concern if you have
+  automated tooling that generates a registration file.
 
 ## Versions v2.0.0-beta.7 and prior
 

--- a/README.md
+++ b/README.md
@@ -47,29 +47,29 @@ backwards compatible.
 
 #### Changes in `v2.0.0-beta.*` (pre-release)
 
-* Draupnir's new core efficiently caches room state and room
+- Draupnir's new core efficiently caches room state and room
   membership allowing Draupnir to be much more responsive than
   Mjolnir.
 
-* Draupnir is much less dependant on commands
+- Draupnir is much less dependant on commands
   and will automatically send prompts to the management room.
   Prompts are sent for inviting Draupnir to protect rooms,
   watch policy lists, ban users, and unban users.
 
-* Draupnir offers a [room state backing
+- Draupnir offers a [room state backing
   store](https://github.com/the-draupnir-project/Draupnir/blob/main/config/default.yaml#L206-L212),
   allowing Draupnir startup quickly, even when deployed at distance
   from the homeserver.
 
-* Draupnir's core functionality is implemented as protections,
+- Draupnir's core functionality is implemented as protections,
   which can be dynamically turned on and off.
 
-* Most effort has been spent refactoring the code base, paving the way
+- Most effort has been spent refactoring the code base, paving the way
   for future feature development and adjacent projects. This includes
   the rewrite of the core of Draupnir into the
   [matrix-protection-suite](https://github.com/Gnuxie/matrix-protection-suite),
   providing all the Matrix client code required to operate a
-  protection platform.  The
+  protection platform. The
   [interface-manager](https://github.com/the-draupnir-project/interface-manager)
   providing an advanced command-oriented interface (note, this does
   not mean command-line interface). The
@@ -79,7 +79,6 @@ backwards compatible.
   [eslint](https://eslint.org/) and
   [typescript-eslint](https://typescript-eslint.io/) into Draupnir's
   development tooling, modernising TypeScript development.
-
 
 #### Changes in latest `v1.87.0`
 

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -2,9 +2,8 @@
 //
 // SPDX-License-Identifier: CC0-1.0
 
-
-import eslint from '@eslint/js';
-import tseslint from 'typescript-eslint';
+import eslint from "@eslint/js";
+import tseslint from "typescript-eslint";
 import tsplugin from "@typescript-eslint/eslint-plugin";
 
 // this configuration file stilli includes random shite from these directories
@@ -12,71 +11,75 @@ import tsplugin from "@typescript-eslint/eslint-plugin";
 // my guess is that there is some hidden ambient config that is included
 // full of eslint defaults that we can't intercept??
 // I don't know, but it's one of the most frustraiting things ever.
-const ignores = ['**/docs/**', '**/.husky/**', '**/coverage/**', '**/dist/**', '**/lib/**'];
+const ignores = [
+  "**/docs/**",
+  "**/.husky/**",
+  "**/coverage/**",
+  "**/dist/**",
+  "**/lib/**",
+];
 
 const rulesFromMPS = {
-    '@typescript-eslint/explicit-function-return-type': 'off',
-    '@typescript-eslint/no-unused-vars': ['error', { argsIgnorePattern: '^_' }],
-    // we implement a lot of interfaces that return promises with synchronous functions.
-    "require-await": "off",
-    "@typescript-eslint/require-await": "off",
-    // we need never because our code can be wrong!
-    "@typescript-eslint/restrict-template-expressions": ['error', { allowNever: true }],
-    // stylistic recommendation that doesn't play well with event emitter interfaces.
-    "@typescript-eslint/unified-signatures": "off",
-    // There are some compelling arguments for including this rule,
-    // but other than using namespaces, we don't have granular enough modules
-    // to be able to depend on their behaviour. This should be revisited.
-    "@typescript-eslint/no-extraneous-class": "off",
-    // We want to be able to create infinite loops.
-    "@typescript-eslint/no-unnecessary-condition": ['error', { allowConstantLoopConditions: true }],
-}
+  "@typescript-eslint/explicit-function-return-type": "off",
+  "@typescript-eslint/no-unused-vars": ["error", { argsIgnorePattern: "^_" }],
+  // we implement a lot of interfaces that return promises with synchronous functions.
+  "require-await": "off",
+  "@typescript-eslint/require-await": "off",
+  // we need never because our code can be wrong!
+  "@typescript-eslint/restrict-template-expressions": [
+    "error",
+    { allowNever: true },
+  ],
+  // stylistic recommendation that doesn't play well with event emitter interfaces.
+  "@typescript-eslint/unified-signatures": "off",
+  // There are some compelling arguments for including this rule,
+  // but other than using namespaces, we don't have granular enough modules
+  // to be able to depend on their behaviour. This should be revisited.
+  "@typescript-eslint/no-extraneous-class": "off",
+  // We want to be able to create infinite loops.
+  "@typescript-eslint/no-unnecessary-condition": [
+    "error",
+    { allowConstantLoopConditions: true },
+  ],
+};
 
 export default tseslint.config({
-    // This is a typescript-eslint configurartion for typescript files.
-    // This will not work against js files.
-    files: [
-        "src/**/*.ts",
-        "src/**/*.tsx",
-        "test/**/*.ts",
-        "test/**/*.tsx"
-    ],
-    extends: [
-        eslint.configs.recommended,
-        ...tseslint.configs.strictTypeChecked,
-    ],
-    languageOptions: {
-        parserOptions: {
-        project: ["./tsconfig.json", "./test/tsconfig.json"],
-        },
+  // This is a typescript-eslint configurartion for typescript files.
+  // This will not work against js files.
+  files: ["src/**/*.ts", "src/**/*.tsx", "test/**/*.ts", "test/**/*.tsx"],
+  extends: [eslint.configs.recommended, ...tseslint.configs.strictTypeChecked],
+  languageOptions: {
+    parserOptions: {
+      project: ["./tsconfig.json", "./test/tsconfig.json"],
     },
-    // This is needed in order to specify the desired behavior for its rules
-    plugins: {
-        '@typescript-eslint': tsplugin,
-    },
-    rules: {
-        // Place to specify ESLint rules. Can be used to overwrite rules specified from the extended configs
-        // e.g. "@typescript-eslint/explicit-function-return-type": "off",
-        ...rulesFromMPS,
+  },
+  // This is needed in order to specify the desired behavior for its rules
+  plugins: {
+    "@typescript-eslint": tsplugin,
+  },
+  rules: {
+    // Place to specify ESLint rules. Can be used to overwrite rules specified from the extended configs
+    // e.g. "@typescript-eslint/explicit-function-return-type": "off",
+    ...rulesFromMPS,
 
-        // There is too much ambient `any` from the `matrix-bot-sdk` in our project to be able to use no-unsafe-*.
-        // We would really love to be able to set this to `error`.
-        "@typescript-eslint/no-unsafe-argument": "off",
-        "@typescript-eslint/no-unsafe-member-access": "off",
-        "@typescript-eslint/no-unsafe-assignment": "off",
-        "@typescript-eslint/no-unsafe-return": "off",
-        "@typescript-eslint/no-unsafe-call": "off",
+    // There is too much ambient `any` from the `matrix-bot-sdk` in our project to be able to use no-unsafe-*.
+    // We would really love to be able to set this to `error`.
+    "@typescript-eslint/no-unsafe-argument": "off",
+    "@typescript-eslint/no-unsafe-member-access": "off",
+    "@typescript-eslint/no-unsafe-assignment": "off",
+    "@typescript-eslint/no-unsafe-return": "off",
+    "@typescript-eslint/no-unsafe-call": "off",
 
-        // We make the mistake of using `unknown` for caught and wrapped exceptions
-        // in matrix-protection-suite...
-        // which causes problems when we unwrap them.
-        // We should probably change `Result` to throw when exception doesn't
-        // implement error.
-        "@typescript-eslint/only-throw-error": "off",
+    // We make the mistake of using `unknown` for caught and wrapped exceptions
+    // in matrix-protection-suite...
+    // which causes problems when we unwrap them.
+    // We should probably change `Result` to throw when exception doesn't
+    // implement error.
+    "@typescript-eslint/only-throw-error": "off",
 
-        "@typescript-eslint/unbound-method": ["error", { ignoreStatic: true }],
+    "@typescript-eslint/unbound-method": ["error", { ignoreStatic: true }],
 
-        "no-constant-condition": ["error", { checkLoops: "allExceptWhileTrue" },]
-    },
-    ignores: [...ignores, '**/*.js', '**/*.jsx'],
+    "no-constant-condition": ["error", { checkLoops: "allExceptWhileTrue" }],
+  },
+  ignores: [...ignores, "**/*.js", "**/*.jsx"],
 });

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "postbuild": "corepack yarn describe-version",
     "describe-version": "(git describe > version.txt.tmp && mv version.txt.tmp version.txt) || true && rm -f version.txt.tmp",
     "remove-tests-from-lib": "rm -rf lib/test/ && cp -r lib/src/* lib/ && rm -rf lib/src/",
-    "lint": "corepack yarn eslint --cache --quiet src test && corepack yarn prettier --cache --ignore-unknown --check src test",
+    "lint": "corepack yarn eslint --cache src test && corepack yarn prettier --cache --ignore-unknown --check src test",
     "start:dev": "corepack yarn build && node --async-stack-traces lib/index.js",
     "test:unit": "mocha --require './test/tsnode.cjs' --forbid-only 'test/unit/**/*.{ts,tsx}'",
     "test:unit:single": "mocha --require test/tsnode.cjs",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "postbuild": "corepack yarn describe-version",
     "describe-version": "(git describe > version.txt.tmp && mv version.txt.tmp version.txt) || true && rm -f version.txt.tmp",
     "remove-tests-from-lib": "rm -rf lib/test/ && cp -r lib/src/* lib/ && rm -rf lib/src/",
-    "lint": "corepack yarn eslint src test && corepack yarn prettier --check src test",
+    "lint": "corepack yarn eslint --cache --quiet src test && corepack yarn prettier --cache --ignore-unknown --check src test",
     "start:dev": "corepack yarn build && node --async-stack-traces lib/index.js",
     "test:unit": "mocha --require './test/tsnode.cjs' --forbid-only 'test/unit/**/*.{ts,tsx}'",
     "test:unit:single": "mocha --require test/tsnode.cjs",


### PR DESCRIPTION
I was informed that there is a goal of not repeating past mistakes in Draupnir and that there was previously breakage due to a script being marked as not executable and upon saying that there are pre-commit hooks for that, I was requested to enable them.

While at that I detected `pre-commit run --all-files` was broken since `pre-commit` was calling `yarn lint` which was passing flags only to one command and missing other flags from `prettier` causing failures.