### PR TITLE
Remove References to Regex in Config Example as they are false

### DIFF
--- a/config/default.yaml
+++ b/config/default.yaml
@@ -185,6 +185,9 @@ protections:
     #
     # WordList will ban users who use these words when first joining a room, so take caution when selecting them.
     #
+    # The word list protection does not support regular expressions at this time.
+    # The configuration in the past stated support for Regex erroneously.
+    #
     words:
       - "LoReM"
       - "IpSuM"

--- a/config/default.yaml
+++ b/config/default.yaml
@@ -185,10 +185,6 @@ protections:
     #
     # WordList will ban users who use these words when first joining a room, so take caution when selecting them.
     #
-    # For advanced usage, regex can also be used, see the following links for more information;
-    #  - https://www.digitalocean.com/community/tutorials/an-introduction-to-regular-expressions
-    #  - https://regexr.com/
-    #  - https://regexone.com/
     words:
       - "LoReM"
       - "IpSuM"


### PR DESCRIPTION
Regex is not supported by wordlist protection so lets strip the references.