### PR TITLE
Make recovery UX clearer.

### DIFF
--- a/src/safemode/RecoveryOptions.tsx
+++ b/src/safemode/RecoveryOptions.tsx
@@ -8,6 +8,7 @@ import {
 } from "@the-draupnir-project/interface-manager";
 import { ConfigRecoverableError } from "matrix-protection-suite";
 import { SafeModeCause, SafeModeReason } from "./SafeModeCause";
+import { MatrixReactionHandler } from "../commands/interface-manager/MatrixReactionHandler";
 
 export function renderRecoveryOptions(cause: SafeModeCause): DocumentNode {
   const recoveryOptions =
@@ -31,6 +32,11 @@ export function renderRecoveryOptions(cause: SafeModeCause): DocumentNode {
           <li>{option.description}</li>
         ))}
       </ol>
+      To use a recovery option, click on one of the reactions (
+      {recoveryOptions
+        .map((_, index) => MatrixReactionHandler.numberToEmoji(index + 1))
+        .join(", ")}
+      ), or use the recover command: <code>!draupnir recover 1</code>.
     </fragment>
   );
 }

--- a/src/safemode/commands/StatusCommand.tsx
+++ b/src/safemode/commands/StatusCommand.tsx
@@ -109,7 +109,7 @@ export function renderSafeModeStatusInfo(
       )}
       <br />
       <br />
-      To attempt to restart, use <code>!draupnir restart</code>
+      To attempt to restart, use <code>!draupnir restart</code>.
     </fragment>
   );
 }


### PR DESCRIPTION

First, we make it clear how to use the recovery options in the safe mode status command:

![Screenshot_20241007_100220](https://github.com/user-attachments/assets/07f49233-6bb1-4320-80c5-ac3aa22c1ef9)


Then a recovery option is used, we show the status of the persistent config again to reinforce to the moderator that the recovery option changed something and fixed it:

![Screenshot_20241007_102045](https://github.com/user-attachments/assets/58156a56-fe17-49e1-a93a-2591dd80aaef)

https://github.com/the-draupnir-project/planning/issues/29
