### PR TITLE
Filesystem config improvements

### DIFF
--- a/src/DraupnirBotMode.ts
+++ b/src/DraupnirBotMode.ts
@@ -11,7 +11,6 @@
 import {
   StandardClientsInRoomMap,
   DefaultEventDecoder,
-  setGlobalLoggerProvider,
   RoomStateBackingStore,
   ClientsInRoomMap,
   Task,
@@ -21,7 +20,6 @@ import {
   ConfigRecoverableError,
 } from "matrix-protection-suite";
 import {
-  BotSDKLogServiceLogger,
   ClientCapabilityFactory,
   MatrixSendClient,
   RoomStateManagerFactory,
@@ -50,8 +48,6 @@ import { SafeModeDraupnir } from "./safemode/DraupnirSafeMode";
 import { ResultError } from "@gnuxie/typescript-result";
 import { SafeModeCause, SafeModeReason } from "./safemode/SafeModeCause";
 import { SafeModeBootOption } from "./safemode/BootOption";
-
-setGlobalLoggerProvider(new BotSDKLogServiceLogger());
 
 const log = new Logger("DraupnirBotMode");
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -259,6 +259,17 @@ export function getDefaultConfig(): IConfig {
   return Config.util.cloneDeep(defaultConfig);
 }
 
+function logNonDefaultConfiguration(config: IConfig): void {
+  log.info(
+    "non-default configuration properties:",
+    JSON.stringify(getNonDefaultConfigProperties(config), null, 2)
+  );
+}
+
+function logConfigMeta(config: IConfig): void {
+  log.info("Configuration meta:", JSON.stringify(config.configMeta, null, 2));
+}
+
 function getConfigPath(): {
   isDraupnirPath: boolean;
   path: string;
@@ -306,18 +317,15 @@ function readConfigSource(): IConfig {
       configMeta: configMeta,
     }) as IConfig;
   })();
+  logConfigMeta(config);
   if (!configMeta.isDraupnirConfigOptionUsed) {
-    log.warn(
+    log.error(
       "DEPRECATED",
       "Starting Draupnir without the --draupnir-config option is deprecated. Please provide Draupnir's configuration explicitly with --draupnir-config.",
       "config path used:",
       config.configMeta?.configPath
     );
   }
-  log.info(
-    "non-default configuration properties loaded:",
-    JSON.stringify(getNonDefaultConfigProperties(config), null, 2)
-  );
   const unknownProperties = getUnknownConfigPropertyPaths(config);
   if (unknownProperties.length > 0) {
     log.warn(
@@ -325,6 +333,10 @@ function readConfigSource(): IConfig {
       unknownProperties
     );
   }
+  process.on("exit", () => {
+    logNonDefaultConfiguration(config);
+    logConfigMeta(config);
+  });
   return config;
 }
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -10,7 +10,7 @@
 
 import * as fs from "fs";
 import { load } from "js-yaml";
-import { MatrixClient, LogService } from "matrix-bot-sdk";
+import { LogService } from "matrix-bot-sdk";
 import Config from "config";
 import path from "path";
 import { SafeModeBootOption } from "./safemode/BootOption";
@@ -156,14 +156,6 @@ export interface IConfig {
   // Experimental usage of the matrix-bot-sdk rust crypto.
   // This can not be used with Pantalaimon.
   experimentalRustCrypto: boolean;
-
-  /**
-   * Config options only set at runtime. Try to avoid using the objects
-   * here as much as possible.
-   */
-  RUNTIME: {
-    client?: MatrixClient;
-  };
 }
 
 const defaultConfig: IConfig = {
@@ -246,9 +238,6 @@ const defaultConfig: IConfig = {
     enabled: false,
   },
   experimentalRustCrypto: false,
-
-  // Needed to make the interface happy.
-  RUNTIME: {},
 };
 
 export function getDefaultConfig(): IConfig {

--- a/src/config.ts
+++ b/src/config.ts
@@ -156,6 +156,11 @@ export interface IConfig {
   // Experimental usage of the matrix-bot-sdk rust crypto.
   // This can not be used with Pantalaimon.
   experimentalRustCrypto: boolean;
+
+  /**
+   * The path that the configuration file was loaded from.
+   */
+  configPath?: string | undefined;
 }
 
 const defaultConfig: IConfig = {
@@ -238,6 +243,7 @@ const defaultConfig: IConfig = {
     enabled: false,
   },
   experimentalRustCrypto: false,
+  configPath: undefined,
 };
 
 export function getDefaultConfig(): IConfig {
@@ -258,13 +264,13 @@ function readConfigSource(): IConfig {
     if (explicitConfigPath !== undefined) {
       const content = fs.readFileSync(explicitConfigPath, "utf8");
       const parsed = load(content);
-      return Config.util.extendDeep({}, defaultConfig, parsed);
+      return Config.util.extendDeep({}, defaultConfig, parsed, {
+        configPath: explicitConfigPath,
+      });
     } else {
-      return Config.util.extendDeep(
-        {},
-        defaultConfig,
-        Config.util.toObject()
-      ) as IConfig;
+      return Config.util.extendDeep({}, defaultConfig, Config.util.toObject(), {
+        configPath: Config.util.getConfigSources().at(-1)?.name,
+      }) as IConfig;
     }
   })();
   log.info(

--- a/src/config.ts
+++ b/src/config.ts
@@ -247,7 +247,7 @@ function readConfigSource(): IConfig {
   }
 }
 
-export function read(): IConfig {
+export function configRead(): IConfig {
   const config = readConfigSource();
   const explicitAccessTokenPath = getCommandLineOption(
     process.argv,
@@ -290,7 +290,7 @@ export function getProvisionedMjolnirConfig(managementRoomId: string): IConfig {
     "backgroundDelayMS",
     "safeMode",
   ];
-  const configTemplate = read(); // we use the standard bot config as a template for every provisioned draupnir.
+  const configTemplate = configRead(); // we use the standard bot config as a template for every provisioned draupnir.
   const unusedKeys = Object.keys(configTemplate).filter(
     (key) => !allowedKeys.includes(key)
   );

--- a/src/config.ts
+++ b/src/config.ts
@@ -250,14 +250,23 @@ export function getDefaultConfig(): IConfig {
   return Config.util.cloneDeep(defaultConfig);
 }
 
+function getExplicitConfigPath(): {
+  isDraupnirPath: boolean;
+  path: string | undefined;
+} {
+  const draupnirPath = getCommandLineOption(process.argv, "--draupnir-config");
+  if (draupnirPath) {
+    return { isDraupnirPath: true, path: draupnirPath };
+  }
+  const mjolnirPath = getCommandLineOption(process.argv, "--mjolnir-config");
+  return { isDraupnirPath: false, path: mjolnirPath };
+}
+
 /**
  * @returns The users's raw config, deep copied over the `defaultConfig`.
  */
 function readConfigSource(): IConfig {
-  const explicitConfigPath = getCommandLineOption(
-    process.argv,
-    "--draupnir-config"
-  );
+  const { isDraupnirPath, path: explicitConfigPath } = getExplicitConfigPath();
   // we probably want to make an incision after this if block.
   // to create the provided values field to the config.
   const config = (() => {
@@ -273,6 +282,14 @@ function readConfigSource(): IConfig {
       }) as IConfig;
     }
   })();
+  if (!isDraupnirPath) {
+    log.warn(
+      "DEPRECATED",
+      "Starting Draupnir without the --draupnir-config option is deprecated. Please provide Draupnir's configuration explicitly with --draupnir-config.",
+      "config path used:",
+      config.configPath
+    );
+  }
   log.info(
     "non-default configuration properties loaded:",
     JSON.stringify(getNonDefaultConfigProperties(config), null, 2)

--- a/src/config.ts
+++ b/src/config.ts
@@ -10,12 +10,14 @@
 
 import * as fs from "fs";
 import { load } from "js-yaml";
-import { LogService } from "matrix-bot-sdk";
+import { LogService, RichConsoleLogger } from "matrix-bot-sdk";
 import Config from "config";
 import path from "path";
 import { SafeModeBootOption } from "./safemode/BootOption";
-import { Logger } from "matrix-protection-suite";
+import { Logger, setGlobalLoggerProvider } from "matrix-protection-suite";
 
+LogService.setLogger(new RichConsoleLogger());
+setGlobalLoggerProvider(new RichConsoleLogger());
 const log = new Logger("Draupnir config");
 
 /**
@@ -319,7 +321,7 @@ function readConfigSource(): IConfig {
   })();
   logConfigMeta(config);
   if (!configMeta.isDraupnirConfigOptionUsed) {
-    log.error(
+    log.warn(
       "DEPRECATED",
       "Starting Draupnir without the --draupnir-config option is deprecated. Please provide Draupnir's configuration explicitly with --draupnir-config.",
       "config path used:",

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,7 +15,6 @@ import {
   LogService,
   MatrixClient,
   PantalaimonClient,
-  RichConsoleLogger,
   SimpleFsStorageProvider,
   RustSdkCryptoStorageProvider,
 } from "matrix-bot-sdk";
@@ -30,7 +29,6 @@ import { SqliteRoomStateBackingStore } from "./backingstore/better-sqlite3/Sqlit
 void (async function () {
   const config = configRead();
 
-  LogService.setLogger(new RichConsoleLogger());
   LogService.setLevel(LogLevel.fromString(config.logLevel, LogLevel.DEBUG));
 
   LogService.info("index", "Starting bot...");

--- a/src/index.ts
+++ b/src/index.ts
@@ -20,7 +20,7 @@ import {
   RustSdkCryptoStorageProvider,
 } from "matrix-bot-sdk";
 import { StoreType } from "@matrix-org/matrix-sdk-crypto-nodejs";
-import { read as configRead } from "./config";
+import { configRead as configRead } from "./config";
 import { initializeSentry, patchMatrixClient } from "./utils";
 import { DraupnirBotModeToggle } from "./DraupnirBotMode";
 import { SafeMatrixEmitterWrapper } from "matrix-protection-suite-for-matrix-bot-sdk";

--- a/test/integration/fixtures.ts
+++ b/test/integration/fixtures.ts
@@ -52,7 +52,6 @@ export const mochaHooks = {
       if (draupnirMatrixClient === null) {
         throw new TypeError(`setup code is broken`);
       }
-      config.RUNTIME.client = draupnirMatrixClient;
       await draupnirClient()?.start();
       await this.toggle.encryptionInitialized();
       console.log("mochaHooks.beforeEach DONE");

--- a/test/integration/fixtures.ts
+++ b/test/integration/fixtures.ts
@@ -12,7 +12,7 @@ import {
   MJOLNIR_PROTECTED_ROOMS_EVENT_TYPE,
   MJOLNIR_WATCHED_POLICY_ROOMS_EVENT_TYPE,
 } from "matrix-protection-suite";
-import { read as configRead } from "../../src/config";
+import { configRead } from "../../src/config";
 import { patchMatrixClient } from "../../src/utils";
 import {
   DraupnirTestContext,

--- a/test/integration/manualLaunchScript.ts
+++ b/test/integration/manualLaunchScript.ts
@@ -13,7 +13,7 @@
  */
 
 import { draupnirClient, makeBotModeToggle } from "./mjolnirSetupUtils";
-import { read as configRead } from "../../src/config";
+import { configRead } from "../../src/config";
 import { SqliteRoomStateBackingStore } from "../../src/backingstore/better-sqlite3/SqliteRoomStateBackingStore";
 import path from "path";
 import { DefaultEventDecoder } from "matrix-protection-suite";

--- a/test/integration/mjolnirSetupUtils.ts
+++ b/test/integration/mjolnirSetupUtils.ts
@@ -14,7 +14,6 @@ import {
   MemoryStorageProvider,
   LogService,
   LogLevel,
-  RichConsoleLogger,
 } from "matrix-bot-sdk";
 import { overrideRatelimitForUser, registerUser } from "./clientHelper";
 import { initializeSentry, patchMatrixClient } from "../../src/utils";
@@ -137,7 +136,6 @@ export async function makeBotModeToggle(
   } = {}
 ): Promise<DraupnirBotModeToggle> {
   await configureMjolnir(config);
-  LogService.setLogger(new RichConsoleLogger());
   LogService.setLevel(LogLevel.fromString(config.logLevel, LogLevel.DEBUG));
   LogService.info("test/mjolnirSetupUtils", "Starting bot...");
   const pantalaimon = new PantalaimonClient(

--- a/test/unit/config/unknownPropertiesTest.ts
+++ b/test/unit/config/unknownPropertiesTest.ts
@@ -1,0 +1,41 @@
+// SPDX-FileCopyrightText: 2024 Gnuxie <Gnuxie@protonmail.com>
+//
+// SPDX-License-Identifier: AFL-3.0
+
+import expect from "expect";
+import {
+  getNonDefaultConfigProperties,
+  getUnknownConfigPropertyPaths,
+} from "../../../src/config";
+import { IConfig } from "../../../src/config";
+
+describe("Test unknown properties detection", () => {
+  it("Should detect when there are typos in the config", function () {
+    const config = {
+      pantalaimon: {
+        use: true,
+        passweird: "my password hehe",
+      },
+    };
+    const unknownProperties = getUnknownConfigPropertyPaths(config);
+    expect(unknownProperties.length).toBe(1);
+    expect(unknownProperties[0]).toBe("/pantalaimon/passweird");
+  });
+});
+
+describe("Test non-default values detection", () => {
+  it("Should detect when there are non-default values in the config", function () {
+    const config = {
+      pantalaimon: {
+        use: true,
+        password: "my password hehe",
+      },
+    };
+    const differentProperties = getNonDefaultConfigProperties(
+      config as IConfig
+    ) as unknown as IConfig;
+    expect(Object.entries(differentProperties).length).toBe(1);
+    expect(differentProperties.pantalaimon.password).toBe("REDACTED");
+    expect(differentProperties.pantalaimon.use).toBe(true);
+  });
+});


### PR DESCRIPTION
Part of: https://github.com/the-draupnir-project/planning/issues/30

Startup:

```
Tue, 08 Oct 2024 11:28:13 GMT [INFO] [Draupnir config] Configuration meta: {
  "configPath": "/home/user/experiments/Draupnir/config/harness.yaml",
  "isDraupnirConfigOptionUsed": false,
  "isAccessTokenPathOptionUsed": false,
  "isPasswordPathOptionUsed": false
}
Tue, 08 Oct 2024 11:28:13 GMT [WARN] [Draupnir config] DEPRECATED Starting Draupnir without the --draupnir-config option is deprecated. Please provide Draupnir's configuration explicitly with --draupnir-config. config path used: /home/user/experiments/Draupnir/config/harness.yaml
```

Crash:

```
Tue, 08 Oct 2024 11:39:38 GMT [INFO] [Draupnir config] non-default configuration properties: {
  "homeserverUrl": "http://localhost:8081",
  "rawHomeserverUrl": "http://localhost:8081",
  "pantalaimon": {
    "use": true,
    "username": "mjolnir",
    "password": "REDACTED"
  },
  "dataPath": "./test/harness/mjolnir-data/",
  "acceptInvitesFromSpace": "!example:example.org",
  "managementRoom": "#moderators:localhost:9999",
  "logLevel": "DEBUG",
  "commands": {
    "additionalPrefixes": [
      "mjolnir_bot"
    ]
  },
  "protections": {
    "wordlist": {
      "words": [
        "CaSe",
        "InSeNsAtIve",
        "WoRd",
        "LiSt"
      ]
    }
  },
  "admin": {
    "enableMakeRoomAdminCommand": true
  },
  "web": {
    "enabled": true,
    "port": 8082,
    "address": "0.0.0.0",
    "abuseReporting": {
      "enabled": true
    }
  },
  "configMeta": {
    "configPath": "/home/user/experiments/Draupnir/config/harness.yaml",
    "isDraupnirConfigOptionUsed": false,
    "isAccessTokenPathOptionUsed": false,
    "isPasswordPathOptionUsed": false
  }
}
Tue, 08 Oct 2024 11:39:38 GMT [INFO] [Draupnir config] Configuration meta: {
  "configPath": "/home/user/experiments/Draupnir/config/harness.yaml",
  "isDraupnirConfigOptionUsed": false,
  "isAccessTokenPathOptionUsed": false,
  "isPasswordPathOptionUsed": false
}
/home/user/experiments/Draupnir/src/config.ts:342
  throw new TypeError("Something broke")
        ^
TypeError: Something broke
    at readConfigSource (/home/user/experiments/Draupnir/src/config.ts:342:9)
    at configRead (/home/user/experiments/Draupnir/src/config.ts:347:18)
    at /home/user/experiments/Draupnir/test/integration/manualLaunchScript.ts:22:28
    at Object.<anonymous> (/home/user/experiments/Draupnir/test/integration/manualLaunchScript.ts:32:3)
    at Module._compile (node:internal/modules/cjs/loader:1369:14)
    at Module.m._compile (/home/user/experiments/Draupnir/node_modules/ts-node/src/index.ts:1618:23)
    at Module._extensions..js (node:internal/modules/cjs/loader:1427:10)
    at Object.require.extensions.<computed> [as .ts] (/home/user/experiments/Draupnir/node_modules/ts-node/src/index.ts:1621:12)
    at Module.load (node:internal/modules/cjs/loader:1206:32)
    at Function.Module._load (node:internal/modules/cjs/loader:1022:12)
Waiting for the debugger to disconnect...
error Command failed with exit code 1.
```