### PR TITLE
Make sure we use exact same version of bot-sdk as matrix-appservice-bridge

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     "js-yaml": "^4.1.0",
     "jsdom": "^24.0.0",
     "matrix-appservice-bridge": "^10.3.1",
-    "matrix-bot-sdk": "npm:@vector-im/matrix-bot-sdk",
+    "matrix-bot-sdk": "npm:@vector-im/matrix-bot-sdk@^0.7.1-element.6",
     "matrix-protection-suite": "npm:@gnuxie/matrix-protection-suite@2.0.0",
     "matrix-protection-suite-for-matrix-bot-sdk": "npm:@gnuxie/matrix-protection-suite-for-matrix-bot-sdk@2.0.0",
     "parse-duration": "^1.0.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2621,7 +2621,7 @@ matrix-appservice@^2.0.0:
     js-yaml "^4.1.0"
     morgan "^1.10.0"
 
-"matrix-bot-sdk@npm:@vector-im/matrix-bot-sdk":
+"matrix-bot-sdk@npm:@vector-im/matrix-bot-sdk@^0.7.1-element.6":
   version "0.7.1-element.6"
   resolved "https://registry.yarnpkg.com/@vector-im/matrix-bot-sdk/-/matrix-bot-sdk-0.7.1-element.6.tgz#d1f8a86d3bd60084d92d150f42a48b25199871e1"
   integrity sha512-0KfyTpQV5eyY4vPUZW89t7EZf1YF0UyFkyYqpsxL/6S7XIlbTMC4onod7vx/QpKC0lSREmwIiXx2JSjExP6CIw==


### PR DESCRIPTION
I don't think this has been a problem but it messes up the dev environment if you want to link all of draupnir's dependencies like matrix-protection-suite, interface-manager and so on.