### PR TITLE
Add titles to protection setting schemas.

### DIFF
--- a/src/protections/BasicFlooding.ts
+++ b/src/protections/BasicFlooding.ts
@@ -39,9 +39,12 @@ const log = new Logger("BasicFloodingProtection");
 export const DEFAULT_MAX_PER_MINUTE = 10;
 const TIMESTAMP_THRESHOLD = 30000; // 30s out of phase
 
-const BasicFloodingProtectionSettings = Type.Object({
-  maxPerMinute: Type.Integer({ default: DEFAULT_MAX_PER_MINUTE }),
-});
+const BasicFloodingProtectionSettings = Type.Object(
+  {
+    maxPerMinute: Type.Integer({ default: DEFAULT_MAX_PER_MINUTE }),
+  },
+  { title: "BasicFloodingProtectionSettings" }
+);
 type BasicFloodingProtectionSettings = EDStatic<
   typeof BasicFloodingProtectionSettings
 >;

--- a/src/protections/JoinWaveShortCircuit.tsx
+++ b/src/protections/JoinWaveShortCircuit.tsx
@@ -49,18 +49,21 @@ const DEFAULT_MAX_PER_TIMESCALE = 50;
 const DEFAULT_TIMESCALE_MINUTES = 60;
 const ONE_MINUTE = 60_000; // 1min in ms
 
-const JoinWaveShortCircuitProtectionSettings = Type.Object({
-  maxPer: Type.Integer({
-    default: DEFAULT_MAX_PER_TIMESCALE,
-    description:
-      "The maximum number of users that can join a room in the timescaleMinutes timescale before the room is set to invite-only.",
-  }),
-  timescaleMinutes: Type.Integer({
-    default: DEFAULT_TIMESCALE_MINUTES,
-    description:
-      "The timescale in minutes over which the maxPer users can join before the room is set to invite-only.",
-  }),
-});
+const JoinWaveShortCircuitProtectionSettings = Type.Object(
+  {
+    maxPer: Type.Integer({
+      default: DEFAULT_MAX_PER_TIMESCALE,
+      description:
+        "The maximum number of users that can join a room in the timescaleMinutes timescale before the room is set to invite-only.",
+    }),
+    timescaleMinutes: Type.Integer({
+      default: DEFAULT_TIMESCALE_MINUTES,
+      description:
+        "The timescale in minutes over which the maxPer users can join before the room is set to invite-only.",
+    }),
+  },
+  { title: "JoinWaveShortCircuitProtectionSettings" }
+);
 
 type JoinWaveShortCircuitProtectionSettings = EDStatic<
   typeof JoinWaveShortCircuitProtectionSettings

--- a/src/protections/TrustedReporters.ts
+++ b/src/protections/TrustedReporters.ts
@@ -32,28 +32,31 @@ import { Type } from "@sinclair/typebox";
 
 const MAX_REPORTED_EVENT_BACKLOG = 20;
 
-const TrustedReportersProtectionSettings = Type.Object({
-  mxids: Type.Array(StringUserIDSchema, {
-    default: [],
-    uniqueItems: true,
-    description: "The users who are marked as trusted reporters.",
-  }),
-  alertThreshold: Type.Integer({
-    default: 3,
-    description:
-      "The number of reports from trusted reporters required before sending an alert to the management room.",
-  }),
-  redactThreshold: Type.Integer({
-    default: -1,
-    description:
-      "The number of reports from trusted reporters required before the relevant event is redacted.",
-  }),
-  banThreshold: Type.Integer({
-    default: -1,
-    description:
-      "The number of reports from trusted reporters required before the reported user banned.",
-  }),
-});
+const TrustedReportersProtectionSettings = Type.Object(
+  {
+    mxids: Type.Array(StringUserIDSchema, {
+      default: [],
+      uniqueItems: true,
+      description: "The users who are marked as trusted reporters.",
+    }),
+    alertThreshold: Type.Integer({
+      default: 3,
+      description:
+        "The number of reports from trusted reporters required before sending an alert to the management room.",
+    }),
+    redactThreshold: Type.Integer({
+      default: -1,
+      description:
+        "The number of reports from trusted reporters required before the relevant event is redacted.",
+    }),
+    banThreshold: Type.Integer({
+      default: -1,
+      description:
+        "The number of reports from trusted reporters required before the reported user banned.",
+    }),
+  },
+  { title: "TrustedReportersProtectionSettings" }
+);
 
 type TrustedReportersProtectionSettings = EDStatic<
   typeof TrustedReportersProtectionSettings


### PR DESCRIPTION
They are appearing as untitled when using the `protections show` command.