### PR TITLE
Prevent Draupnir triggering its own Flooding & WordList protections

### DIFF
--- a/src/protections/BasicFlooding.ts
+++ b/src/protections/BasicFlooding.ts
@@ -168,6 +168,11 @@ export class BasicFloodingProtection
     room: MatrixRoomID,
     event: RoomEvent
   ): Promise<ActionResult<void>> {
+    // If the sender is draupnir, ignore the message
+    if (event["sender"] === this.draupnir.clientUserID) {
+      log.info(`Ignoring message from self: ${event.event_id}`);
+      return Ok(undefined);
+    }
     const forUser = lastEventsForUser(
       this.lastEvents,
       event.room_id,

--- a/src/protections/WordList.ts
+++ b/src/protections/WordList.ts
@@ -150,6 +150,12 @@ export class WordListProtection
         event.content["body"];
       const roomID = room.toRoomIDOrAlias();
 
+      // If the sender is draupnir, ignore the message
+      if (event["sender"] === this.draupnir.clientUserID) {
+        log.info(`Ignoring message from self: ${event.event_id}`);
+        return Ok(undefined);
+      }
+
       // Check conditions first
       if (minsBeforeTrusting > 0) {
         const roomEntry = this.justJoined.get(roomID);

--- a/src/protections/WordList.ts
+++ b/src/protections/WordList.ts
@@ -138,6 +138,11 @@ export class WordListProtection
     room: MatrixRoomID,
     event: RoomEvent
   ): Promise<ActionResult<void>> {
+    // If the sender is draupnir, ignore the message
+    if (event["sender"] === this.draupnir.clientUserID) {
+      log.info(`Ignoring message from self: ${event.event_id}`);
+      return Ok(undefined);
+    }
     const minsBeforeTrusting =
       this.draupnir.config.protections.wordlist.minutesBeforeTrusting;
     if (Value.Check(RoomMessage, event)) {
@@ -149,12 +154,6 @@ export class WordListProtection
           event.content["formatted_body"]) ||
         event.content["body"];
       const roomID = room.toRoomIDOrAlias();
-
-      // If the sender is draupnir, ignore the message
-      if (event["sender"] === this.draupnir.clientUserID) {
-        log.info(`Ignoring message from self: ${event.event_id}`);
-        return Ok(undefined);
-      }
 
       // Check conditions first
       if (minsBeforeTrusting > 0) {


### PR DESCRIPTION
Fixes the issue displayed in #579 and #559
(fixes #579, fixes #559)

This PR simply adds a check to the start of the execution chain for WordList and BasicFlooding that just returns an Ok result when the event sender was the client's user ID.
I just tested this and can confirm that this prevents the reported loops in WordList and BasicFlooding, as intended.