### PR TITLE
Fix rooms being added as a server ban policy

### DIFF
--- a/src/commands/Ban.tsx
+++ b/src/commands/Ban.tsx
@@ -155,7 +155,7 @@ export const DraupnirBanCommand = describeCommand({
         return resolvedRoomReference;
       }
       return await policyListEditor.banEntity(
-        PolicyRuleType.Server,
+        PolicyRuleType.Room,
         resolvedRoomReference.ok.toRoomIDOrAlias(),
         reason
       );


### PR DESCRIPTION
Fixes #458. Thought this was a fluke at first since I only changed one word, but it appears to work reliably and as intended.