### PR TITLE
Only kick members whose membership is `join`

### DIFF
--- a/src/commands/KickCommand.tsx
+++ b/src/commands/KickCommand.tsx
@@ -157,7 +157,7 @@ export const DraupnirKickCommand = describeCommand({
     const usersToKick: UsersToKick = new Map();
     for (const revision of roomsToKickWithin) {
       for (const member of revision.members()) {
-        if (kickRule.test(member.userID)) {
+        if (kickRule.test(member.userID) && member.membership === "join") {
           addUserToKick(
             usersToKick,
             revision.room.toRoomIDOrAlias(),

--- a/src/commands/KickCommand.tsx
+++ b/src/commands/KickCommand.tsx
@@ -159,7 +159,7 @@ export const DraupnirKickCommand = describeCommand({
       for (const member of revision.members()) {
         if (
           kickRule.test(member.userID) &&
-          ["join", "invite"].includes(member.membership)
+          ["invite", "join", "knock"].includes(member.membership)
         ) {
           addUserToKick(
             usersToKick,

--- a/src/commands/KickCommand.tsx
+++ b/src/commands/KickCommand.tsx
@@ -16,6 +16,7 @@ import {
   RoomResolver,
   SetRoomMembership,
   isError,
+  Membership,
 } from "matrix-protection-suite";
 import {
   StringUserID,
@@ -157,31 +158,26 @@ export const DraupnirKickCommand = describeCommand({
     const usersToKick: UsersToKick = new Map();
     for (const revision of roomsToKickWithin) {
       for (const member of revision.members()) {
-        switch (member.membership)
+        switch (member.membership) {
           case Membership.Join:
           case Membership.Invite:
           case Membership.Knock: {
-            if (kickRule.test(membership.userID)) {
+            if (kickRule.test(member.userID)) {
               addUserToKick(
                 usersToKick,
                 revision.room.toRoomIDOrAlias(),
                 member.userID
               );
+              if (!isDryRun) {
+                taskQueue.push(() => {
+                  return roomKicker.kickUser(
+                    revision.room.toRoomIDOrAlias(),
+                    member.userID,
+                    reason
+                  );
+                });
+              }
             }
-          }
-          addUserToKick(
-            usersToKick,
-            revision.room.toRoomIDOrAlias(),
-            member.userID
-          );
-          if (!isDryRun) {
-            taskQueue.push(() => {
-              return roomKicker.kickUser(
-                revision.room.toRoomIDOrAlias(),
-                member.userID,
-                reason
-              );
-            });
           }
         }
       }

--- a/src/commands/KickCommand.tsx
+++ b/src/commands/KickCommand.tsx
@@ -157,10 +157,18 @@ export const DraupnirKickCommand = describeCommand({
     const usersToKick: UsersToKick = new Map();
     for (const revision of roomsToKickWithin) {
       for (const member of revision.members()) {
-        if (
-          kickRule.test(member.userID) &&
-          ["invite", "join", "knock"].includes(member.membership)
-        ) {
+        switch (member.membership)
+          case Membership.Join:
+          case Membership.Invite:
+          case Membership.Knock: {
+            if (kickRule.test(membership.userID)) {
+              addUserToKick(
+                usersToKick,
+                revision.room.toRoomIDOrAlias(),
+                member.userID
+              );
+            }
+          }
           addUserToKick(
             usersToKick,
             revision.room.toRoomIDOrAlias(),

--- a/src/commands/KickCommand.tsx
+++ b/src/commands/KickCommand.tsx
@@ -157,7 +157,10 @@ export const DraupnirKickCommand = describeCommand({
     const usersToKick: UsersToKick = new Map();
     for (const revision of roomsToKickWithin) {
       for (const member of revision.members()) {
-        if (kickRule.test(member.userID) && member.membership === "join") {
+        if (
+          kickRule.test(member.userID) &&
+          ["join", "invite"].includes(member.membership)
+        ) {
           addUserToKick(
             usersToKick,
             revision.room.toRoomIDOrAlias(),


### PR DESCRIPTION
Fixes #649. Only members who have the `join` membership state will be kicked, which means that not only will banned members not be implicitly unbanned (bug in ruma, and conduits), but draupnir will also no-longer send no-op leave events.