### PR TITLE
Don't send the banned word in the ban reason

### DIFF
--- a/src/protections/WordList.ts
+++ b/src/protections/WordList.ts
@@ -201,10 +201,6 @@ export class WordListProtection
           event.sender,
           reason
         );
-        // await this.draupnir.client.sendMessage(this.draupnir.managementRoomID, {
-        //   msgtype: "m.notice",
-        //   body: `Banned ${event.sender} in ${roomID} for saying '${match[0]}'.`,
-        // });
         const messageResult = await this.draupnir.client
           .sendMessage(this.draupnir.managementRoomID, {
             msgtype: "m.notice",

--- a/src/protections/WordList.ts
+++ b/src/protections/WordList.ts
@@ -193,12 +193,16 @@ export class WordListProtection
 
       const match = this.badWords.exec(message);
       if (match) {
-        const reason = `bad word: ${match[0]}`;
+        const reason = `Said a bad word. Moderators, consult the management room for more information.`;
         await this.userConsequences.consequenceForUserInRoom(
           roomID,
           event.sender,
           reason
         );
+        await this.draupnir.client.sendMessage(this.draupnir.managementRoomID, {
+          msgtype: "m.notice",
+          body: `Banned ${event.sender} in ${roomID} for saying '${match[0]}'.`,
+        });
         await this.eventConsequences.consequenceForEvent(
           roomID,
           event.event_id,


### PR DESCRIPTION
This change makes the ban reason when a user sends a banned word generic, and instead sends the banned word in the management room directly. This prevents the banned word from persisting in the room timeline after redacting the original event.