### PR TITLE
Add --invite to `unban` command

### DIFF
--- a/src/commands/Unban.ts
+++ b/src/commands/Unban.ts
@@ -67,14 +67,11 @@ async function unbanUserFromRooms(
         continue;
       }
       if (rule.test(member.userID)) {
-        let logMessage = `Unbanning ${member.userID} in ${revision.room.toRoomIDOrAlias()}`;
-        if (invite) {
-          logMessage += ", and re-inviting them.";
-        }
         await managementRoomOutput.logMessage(
           LogLevel.DEBUG,
           "Unban",
-          logMessage,
+          `Unbanning ${member.userID} in ${revision.room.toRoomIDOrAlias()}` +
+            (invite ? ", and re-inviting them." : ""),
           revision.room.toRoomIDOrAlias()
         );
         if (!noop) {

--- a/test/unit/commands/UnbanCommandTest.ts
+++ b/test/unit/commands/UnbanCommandTest.ts
@@ -17,6 +17,7 @@ import {
   PolicyRuleType,
   PowerLevelsEventContent,
   Recommendation,
+  RoomInviter,
   RoomResolver,
   RoomUnbanner,
   describeProtectedRoomsSet,
@@ -136,6 +137,11 @@ describe("Test the DraupnirUnbanCommand", function () {
         noop: false,
         roomUnbanner,
         unlistedUserRedactionQueue: createMock<UnlistedUserRedactionQueue>(),
+        roomInviter: createMock<RoomInviter>({
+          async inviteUser() {
+            return Ok(undefined);
+          },
+        }),
       },
       {
         rest: ["spam"],


### PR DESCRIPTION
This PR closes #622 by adding a `--invite` flag to the `unban` command.

This still needs a bit of work and does not currently work/pass tests, will complete later.