### PR TITLE
Fix the individual request rate-limit

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -492,10 +492,18 @@ function patchMatrixClientForRetry() {
         return cb(...result);
       } catch (err) {
         // Need to retry.
-        const retryAfterMs =
-          "retryAfterMs" in err
-            ? err.retryAfterMs
-            : attempt * attempt * REQUEST_RETRY_BASE_DURATION_MS;
+        const retryAfterMs = (() => {
+          if (err instanceof MatrixError && err.retryAfterMs !== undefined) {
+            return err.retryAfterMs;
+          } else {
+            LogService.error(
+              "Draupnir.client",
+              "Unable to extract retry_after_ms from error, using fallback to create retry duration",
+              err
+            );
+            return attempt * attempt * REQUEST_RETRY_BASE_DURATION_MS;
+          }
+        })();
         LogService.debug(
           "Draupnir.client",
           `Waiting ${retryAfterMs}ms before retrying ${params.method} ${params.uri}`

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -492,14 +492,10 @@ function patchMatrixClientForRetry() {
         return cb(...result);
       } catch (err) {
         // Need to retry.
-        let retryAfterMs = attempt * attempt * REQUEST_RETRY_BASE_DURATION_MS;
-        if ("retry_after_ms" in err) {
-          try {
-            retryAfterMs = Number.parseInt(err.retry_after_ms, 10);
-          } catch (ex) {
-            // Use default value.
-          }
-        }
+        const retryAfterMs =
+          "retryAfterMs" in err
+            ? err.retryAfterMs
+            : attempt * attempt * REQUEST_RETRY_BASE_DURATION_MS;
         LogService.debug(
           "Draupnir.client",
           `Waiting ${retryAfterMs}ms before retrying ${params.method} ${params.uri}`


### PR DESCRIPTION
This fixes the first problem raised in #693 by making the retry logic only use the fallback calculation if the server-provided retry-after is missing