### PR TITLE
Trim spaces and newlines from secret files

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -352,13 +352,13 @@ export function configRead(): IConfig {
     "--pantalaimon-password-path"
   );
   if (explicitAccessTokenPath !== undefined) {
-    config.accessToken = fs.readFileSync(explicitAccessTokenPath, "utf8");
+    config.accessToken = fs.readFileSync(explicitAccessTokenPath, "utf8").trim();
   }
   if (explicitPantalaimonPasswordPath) {
     config.pantalaimon.password = fs.readFileSync(
       explicitPantalaimonPasswordPath,
       "utf8"
-    );
+    ).trim();
   }
   return config;
 }

--- a/src/config.ts
+++ b/src/config.ts
@@ -352,13 +352,14 @@ export function configRead(): IConfig {
     "--pantalaimon-password-path"
   );
   if (explicitAccessTokenPath !== undefined) {
-    config.accessToken = fs.readFileSync(explicitAccessTokenPath, "utf8").trim();
+    config.accessToken = fs
+      .readFileSync(explicitAccessTokenPath, "utf8")
+      .trim();
   }
   if (explicitPantalaimonPasswordPath) {
-    config.pantalaimon.password = fs.readFileSync(
-      explicitPantalaimonPasswordPath,
-      "utf8"
-    ).trim();
+    config.pantalaimon.password = fs
+      .readFileSync(explicitPantalaimonPasswordPath, "utf8")
+      .trim();
   }
   return config;
 }

--- a/src/config.ts
+++ b/src/config.ts
@@ -352,14 +352,12 @@ export function configRead(): IConfig {
     "--pantalaimon-password-path"
   );
   if (explicitAccessTokenPath !== undefined) {
-    config.accessToken = fs
-      .readFileSync(explicitAccessTokenPath, "utf8")
-      .trim();
+    config.accessToken = readSecretFromPath(explicitAccessTokenPath);
   }
   if (explicitPantalaimonPasswordPath) {
-    config.pantalaimon.password = fs
-      .readFileSync(explicitPantalaimonPasswordPath, "utf8")
-      .trim();
+    config.pantalaimon.password = readSecretFromPath(
+      explicitPantalaimonPasswordPath
+    );
   }
   return config;
 }
@@ -483,6 +481,15 @@ function getCommandLineOption(
 
   // No value was provided, or the next argument is another option
   throw new Error(`No value provided for ${optionName}`);
+}
+
+function readSecretFromPath(path: string): string {
+  // extract only the first line.
+  const secret = fs.readFileSync(path, "utf8").match(/^[^\r\n]*/)?.[0];
+  if (!secret) {
+    throw new TypeError(`There is no secret present in the file at ${path}`);
+  }
+  return secret;
 }
 
 type UnknownPropertyPaths = string[];


### PR DESCRIPTION
Purely a UX change for admins, since most text editors append a newline to written files.