### PR TITLE
Command prefix fixes

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "@gnuxie/typescript-result": "^1.0.0",
     "@sentry/node": "^7.17.2",
     "@sinclair/typebox": "0.34.13",
-    "@the-draupnir-project/interface-manager": "3.0.0",
+    "@the-draupnir-project/interface-manager": "4.0.0",
     "@the-draupnir-project/matrix-basic-types": "^0.2.0",
     "better-sqlite3": "^9.4.3",
     "body-parser": "^1.20.2",

--- a/src/Draupnir.ts
+++ b/src/Draupnir.ts
@@ -126,6 +126,7 @@ export class Draupnir implements Client, MatrixAdaptorContext {
   private constructor(
     public readonly client: MatrixSendClient,
     public readonly clientUserID: StringUserID,
+    public clientDisplayName: string,
     public readonly clientPlatform: ClientPlatform,
     public readonly managementRoomDetail: ManagementRoomDetail,
     public readonly clientRooms: ClientRooms,
@@ -186,6 +187,7 @@ export class Draupnir implements Client, MatrixAdaptorContext {
   public static async makeDraupnirBot(
     client: MatrixSendClient,
     clientUserID: StringUserID,
+    clientDisplayName: string,
     clientPlatform: ClientPlatform,
     managementRoomDetail: ManagementRoomDetail,
     clientRooms: ClientRooms,
@@ -240,6 +242,7 @@ export class Draupnir implements Client, MatrixAdaptorContext {
     const draupnir = new Draupnir(
       client,
       clientUserID,
+      clientDisplayName,
       clientPlatform,
       managementRoomDetail,
       clientRooms,

--- a/src/commands/DraupnirCommandDispatcher.ts
+++ b/src/commands/DraupnirCommandDispatcher.ts
@@ -10,10 +10,11 @@
 import {
   MatrixInterfaceCommandDispatcher,
   StandardMatrixInterfaceCommandDispatcher,
-  CommandPrefixExtractor,
   JSInterfaceCommandDispatcher,
   BasicInvocationInformation,
   StandardJSInterfaceCommandDispatcher,
+  CommandNormaliser,
+  makeCommandNormaliser,
 } from "@the-draupnir-project/interface-manager";
 import { Draupnir } from "../Draupnir";
 import {
@@ -22,33 +23,29 @@ import {
   invocationInformationFromMatrixEventcontext,
 } from "./interface-manager/MPSMatrixInterfaceAdaptor";
 import { DraupnirHelpCommand } from "./Help";
-import { userLocalpart } from "@the-draupnir-project/matrix-basic-types";
+import { StringUserID } from "@the-draupnir-project/matrix-basic-types";
 import { DraupnirTopLevelCommands } from "./DraupnirCommandTable";
 import {
   DraupnirContextToCommandContextTranslator,
   DraupnirInterfaceAdaptor,
 } from "./DraupnirCommandPrerequisites";
 import "./DraupnirCommands";
+import { IConfig } from "../config";
 
-function makePrefixExtractor(draupnir: Draupnir): CommandPrefixExtractor {
-  const plainPrefixes = [
-    "!draupnir",
-    userLocalpart(draupnir.clientUserID),
-    draupnir.clientUserID,
-    ...draupnir.config.commands.additionalPrefixes,
-  ];
-  const allPossiblePrefixes = [
-    ...plainPrefixes.map((p) => `!${p}`),
-    ...plainPrefixes.map((p) => `${p}:`),
-    ...plainPrefixes,
-    ...(draupnir.config.commands.allowNoPrefix ? ["!"] : []),
-  ];
-  return (body) => {
-    const isPrefixUsed = allPossiblePrefixes.find((p) =>
-      body.toLowerCase().startsWith(p.toLowerCase())
-    );
-    return isPrefixUsed ? "draupnir" : undefined;
-  };
+export function makeDraupnirCommandNormaliser(
+  clientUserID: StringUserID,
+  config: IConfig
+): CommandNormaliser {
+  return makeCommandNormaliser(clientUserID, {
+    symbolPrefixes: ["!"],
+    isAllowedOnlySymbolPrefixes: config.commands.allowNoPrefix,
+    additionalPrefixes: ["draupnir", ...config.commands.additionalPrefixes],
+    getDisplayName: function (): string {
+      // TODO: We'll have the displayname cached somewhere one day and dynamically updated.
+      return "draupnir";
+    },
+    normalisedPrefix: "draupnir",
+  });
 }
 
 export function makeDraupnirCommandDispatcher(
@@ -62,7 +59,10 @@ export function makeDraupnirCommandDispatcher(
     invocationInformationFromMatrixEventcontext,
     {
       ...MPSCommandDispatcherCallbacks,
-      prefixExtractor: makePrefixExtractor(draupnir),
+      commandNormaliser: makeDraupnirCommandNormaliser(
+        draupnir.clientUserID,
+        draupnir.config
+      ),
     }
   );
 }
@@ -76,7 +76,10 @@ export function makeDraupnirJSCommandDispatcher(
     draupnir,
     {
       ...MPSCommandDispatcherCallbacks,
-      prefixExtractor: makePrefixExtractor(draupnir),
+      commandNormaliser: makeDraupnirCommandNormaliser(
+        draupnir.clientUserID,
+        draupnir.config
+      ),
     },
     DraupnirContextToCommandContextTranslator
   );

--- a/src/commands/DraupnirCommandDispatcher.ts
+++ b/src/commands/DraupnirCommandDispatcher.ts
@@ -34,6 +34,7 @@ import { IConfig } from "../config";
 
 export function makeDraupnirCommandNormaliser(
   clientUserID: StringUserID,
+  displayNameIssuer: { clientDisplayName: string },
   config: IConfig
 ): CommandNormaliser {
   return makeCommandNormaliser(clientUserID, {
@@ -41,8 +42,7 @@ export function makeDraupnirCommandNormaliser(
     isAllowedOnlySymbolPrefixes: config.commands.allowNoPrefix,
     additionalPrefixes: ["draupnir", ...config.commands.additionalPrefixes],
     getDisplayName: function (): string {
-      // TODO: We'll have the displayname cached somewhere one day and dynamically updated.
-      return "draupnir";
+      return displayNameIssuer.clientDisplayName;
     },
     normalisedPrefix: "draupnir",
   });
@@ -61,6 +61,7 @@ export function makeDraupnirCommandDispatcher(
       ...MPSCommandDispatcherCallbacks,
       commandNormaliser: makeDraupnirCommandNormaliser(
         draupnir.clientUserID,
+        draupnir,
         draupnir.config
       ),
     }
@@ -78,6 +79,7 @@ export function makeDraupnirJSCommandDispatcher(
       ...MPSCommandDispatcherCallbacks,
       commandNormaliser: makeDraupnirCommandNormaliser(
         draupnir.clientUserID,
+        draupnir,
         draupnir.config
       ),
     },

--- a/src/commands/interface-manager/MPSMatrixInterfaceAdaptor.ts
+++ b/src/commands/interface-manager/MPSMatrixInterfaceAdaptor.ts
@@ -180,6 +180,9 @@ export const MPSCommandDispatcherCallbacks = {
       error.message
     );
   },
+  commandNormaliser(body) {
+    return body;
+  },
 } satisfies CommandDispatcherCallbacks<BasicInvocationInformation>;
 
 export const rendererFailedCB: MatrixInterfaceRendererFailedCB<

--- a/src/safemode/DraupnirSafeMode.ts
+++ b/src/safemode/DraupnirSafeMode.ts
@@ -59,6 +59,7 @@ export class SafeModeDraupnir implements MatrixAdaptorContext {
     public readonly cause: SafeModeCause,
     public readonly client: MatrixSendClient,
     public readonly clientUserID: StringUserID,
+    public clientDisplayName: string,
     public readonly clientPlatform: ClientPlatform,
     public readonly managementRoom: MatrixRoomID,
     private readonly clientRooms: ClientRooms,

--- a/src/safemode/SafeModeCommandDispatcher.ts
+++ b/src/safemode/SafeModeCommandDispatcher.ts
@@ -4,7 +4,6 @@
 
 import {
   BasicInvocationInformation,
-  CommandPrefixExtractor,
   JSInterfaceCommandDispatcher,
   MatrixInterfaceCommandDispatcher,
   StandardJSInterfaceCommandDispatcher,
@@ -16,35 +15,13 @@ import {
   MatrixEventContext,
   invocationInformationFromMatrixEventcontext,
 } from "../commands/interface-manager/MPSMatrixInterfaceAdaptor";
-import { userLocalpart } from "@the-draupnir-project/matrix-basic-types";
 import { SafeModeCommands } from "./commands/SafeModeCommands";
 import { SafeModeHelpCommand } from "./commands/HelpCommand";
 import {
   SafeModeContextToCommandContextTranslator,
   SafeModeInterfaceAdaptor,
 } from "./commands/SafeModeAdaptor";
-
-function makePrefixExtractor(
-  safeModeDraupnir: SafeModeDraupnir
-): CommandPrefixExtractor {
-  const plainPrefixes = [
-    "!draupnir",
-    userLocalpart(safeModeDraupnir.clientUserID),
-    safeModeDraupnir.clientUserID,
-  ];
-  const allPossiblePrefixes = [
-    ...plainPrefixes.map((p) => `!${p}`),
-    ...plainPrefixes.map((p) => `${p}:`),
-    ...plainPrefixes,
-    ...(safeModeDraupnir.config.commands.allowNoPrefix ? ["!"] : []),
-  ];
-  return (body) => {
-    const isPrefixUsed = allPossiblePrefixes.find((p) =>
-      body.toLowerCase().startsWith(p.toLowerCase())
-    );
-    return isPrefixUsed ? "draupnir" : undefined;
-  };
-}
+import { makeDraupnirCommandNormaliser } from "../commands/DraupnirCommandDispatcher";
 
 export function makeSafeModeCommandDispatcher(
   safeModeDraupnir: SafeModeDraupnir
@@ -57,7 +34,10 @@ export function makeSafeModeCommandDispatcher(
     invocationInformationFromMatrixEventcontext,
     {
       ...MPSCommandDispatcherCallbacks,
-      prefixExtractor: makePrefixExtractor(safeModeDraupnir),
+      commandNormaliser: makeDraupnirCommandNormaliser(
+        safeModeDraupnir.clientUserID,
+        safeModeDraupnir.config
+      ),
     }
   );
 }
@@ -71,7 +51,10 @@ export function makeSafeModeJSDispatcher(
     safeModeDraupnir,
     {
       ...MPSCommandDispatcherCallbacks,
-      prefixExtractor: makePrefixExtractor(safeModeDraupnir),
+      commandNormaliser: makeDraupnirCommandNormaliser(
+        safeModeDraupnir.clientUserID,
+        safeModeDraupnir.config
+      ),
     },
     SafeModeContextToCommandContextTranslator
   );

--- a/src/safemode/SafeModeCommandDispatcher.ts
+++ b/src/safemode/SafeModeCommandDispatcher.ts
@@ -36,6 +36,7 @@ export function makeSafeModeCommandDispatcher(
       ...MPSCommandDispatcherCallbacks,
       commandNormaliser: makeDraupnirCommandNormaliser(
         safeModeDraupnir.clientUserID,
+        safeModeDraupnir,
         safeModeDraupnir.config
       ),
     }
@@ -53,6 +54,7 @@ export function makeSafeModeJSDispatcher(
       ...MPSCommandDispatcherCallbacks,
       commandNormaliser: makeDraupnirCommandNormaliser(
         safeModeDraupnir.clientUserID,
+        safeModeDraupnir,
         safeModeDraupnir.config
       ),
     },

--- a/yarn.lock
+++ b/yarn.lock
@@ -311,10 +311,10 @@
   resolved "https://registry.yarnpkg.com/@sinclair/typebox/-/typebox-0.27.8.tgz#6667fac16c436b5434a387a34dedb013198f6e6e"
   integrity sha512-+Fj43pSMwJs4KRrH/938Uf+uAELIgVBmQzg/q1YG10djyfA3TnrU8N8XzqCh/okZdszqBQTZf96idMfE5lnwTA==
 
-"@the-draupnir-project/interface-manager@3.0.0":
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/@the-draupnir-project/interface-manager/-/interface-manager-3.0.0.tgz#8aedad18be4f33a098e5dc2e74ed8590ca1aba68"
-  integrity sha512-TRPBf+JqcwHS8ARp2FXQhIGcvBrXhUEB16oCKQAybUqMN6f9G7hKP0WQnT1A+IK9xWkG1eAtyUf2HX1LUzwLxg==
+"@the-draupnir-project/interface-manager@4.0.0":
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/@the-draupnir-project/interface-manager/-/interface-manager-4.0.0.tgz#068f4d22ee1f4c964879b1a3f0a619bec1a655c6"
+  integrity sha512-szatmeDnJgkeEBSwdvMRNum/CKVB15WVbN+0gIJQOsZZihQy6PZ4CGl9pLuV49E24kcFK9Z2our0Ut4N3oCAZA==
   dependencies:
     "@gnuxie/super-cool-stream" "^0.2.1"
     "@gnuxie/typescript-result" "^1.0.0"


### PR DESCRIPTION
We have added a "command normaliser" to interface-manager that can cover all the edge cases for pinging the bot or prefixing a command.

Fixes https://github.com/the-draupnir-project/Draupnir/issues/678
Fixes https://github.com/the-draupnir-project/Draupnir/issues/686