### PR TITLE
Update to interface-manager v4.0.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "@gnuxie/typescript-result": "^1.0.0",
     "@sentry/node": "^7.17.2",
     "@sinclair/typebox": "0.34.13",
-    "@the-draupnir-project/interface-manager": "4.0.0",
+    "@the-draupnir-project/interface-manager": "4.0.1",
     "@the-draupnir-project/matrix-basic-types": "^0.2.0",
     "better-sqlite3": "^9.4.3",
     "body-parser": "^1.20.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -311,10 +311,10 @@
   resolved "https://registry.yarnpkg.com/@sinclair/typebox/-/typebox-0.27.8.tgz#6667fac16c436b5434a387a34dedb013198f6e6e"
   integrity sha512-+Fj43pSMwJs4KRrH/938Uf+uAELIgVBmQzg/q1YG10djyfA3TnrU8N8XzqCh/okZdszqBQTZf96idMfE5lnwTA==
 
-"@the-draupnir-project/interface-manager@4.0.0":
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/@the-draupnir-project/interface-manager/-/interface-manager-4.0.0.tgz#068f4d22ee1f4c964879b1a3f0a619bec1a655c6"
-  integrity sha512-szatmeDnJgkeEBSwdvMRNum/CKVB15WVbN+0gIJQOsZZihQy6PZ4CGl9pLuV49E24kcFK9Z2our0Ut4N3oCAZA==
+"@the-draupnir-project/interface-manager@4.0.1":
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/@the-draupnir-project/interface-manager/-/interface-manager-4.0.1.tgz#452a09a6c9024347930d0db80e440e83a9e554af"
+  integrity sha512-nLMNfVYzFIyqZLk8+C5Ujjs09XJOgcK0ufDdzk9Jf1/LEg56NGw7nwWKK9dgub9zp2r/xMSIKnXdSNOGiO+Rvg==
   dependencies:
     "@gnuxie/super-cool-stream" "^0.2.1"
     "@gnuxie/typescript-result" "^1.0.0"


### PR DESCRIPTION
- The signature of the `CommandDispatcher` `prefixExtractor` callback has been changed so that it is possible to transform the entire command body with a `commandNormaliser`.  This was changed primarily to fix https://github.com/the-draupnir-project/Draupnir/issues/707.

Fixes https://github.com/the-draupnir-project/Draupnir/issues/707.