### PR TITLE
Show a protection's compatible capability providers in the capability set section of `!draupnir protections show`.

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,8 +63,8 @@
     "jsdom": "^24.0.0",
     "matrix-appservice-bridge": "^10.3.1",
     "matrix-bot-sdk": "npm:@vector-im/matrix-bot-sdk@^0.7.1-element.6",
-    "matrix-protection-suite": "npm:@gnuxie/matrix-protection-suite@2.7.0",
-    "matrix-protection-suite-for-matrix-bot-sdk": "npm:@gnuxie/matrix-protection-suite-for-matrix-bot-sdk@2.7.0",
+    "matrix-protection-suite": "npm:@gnuxie/matrix-protection-suite@2.8.0",
+    "matrix-protection-suite-for-matrix-bot-sdk": "npm:@gnuxie/matrix-protection-suite-for-matrix-bot-sdk@2.8.0",
     "pg": "^8.8.0",
     "yaml": "^2.3.2"
   },

--- a/src/commands/ProtectionsShowCommand.tsx
+++ b/src/commands/ProtectionsShowCommand.tsx
@@ -16,6 +16,7 @@ import {
   CapabilityProviderSet,
   Protection,
   ProtectionDescription,
+  findCompatibleCapabilityProviders,
   findProtection,
 } from "matrix-protection-suite";
 import { DraupnirInterfaceAdaptor } from "./DraupnirCommandPrerequisites";
@@ -113,8 +114,13 @@ DraupnirInterfaceAdaptor.describeRenderer(DraupnirProtectionsShowCommand, {
         </p>
 
         <h3>Capability provider set</h3>
-        {renderCapabilityProviderSet(
-          protectionInfo.activeCapabilityProviderSet
+        {Object.keys(protectionInfo.activeCapabilityProviderSet).length ===
+        0 ? (
+          <p>There are no configurable capabilities for this protection.</p>
+        ) : (
+          renderCapabilityProviderSet(
+            protectionInfo.activeCapabilityProviderSet
+          )
         )}
       </root>
     );
@@ -125,14 +131,26 @@ function renderCapabilityProvider(
   name: string,
   capabilityProvider: CapabilityProviderDescription
 ): DocumentNode {
+  const compatibleProviders = findCompatibleCapabilityProviders(
+    capabilityProvider.interface.name
+  );
   return (
-    <fragment>
-      <p>
+    <details>
+      <summary>
         <code>{name}</code>: interface:{" "}
         <code>{capabilityProvider.interface.name}</code>
         provider: <code>{capabilityProvider.name}</code>
-      </p>
-    </fragment>
+      </summary>
+      interface description: {capabilityProvider.interface.description}
+      <h4>compatible capabilities:</h4>
+      <ul>
+        {compatibleProviders.map((capability) => (
+          <li>
+            <code>{capability.name}</code> - {capability.description}
+          </li>
+        ))}
+      </ul>
+    </details>
   );
 }
 

--- a/src/commands/ProtectionsShowCommand.tsx
+++ b/src/commands/ProtectionsShowCommand.tsx
@@ -138,7 +138,7 @@ function renderCapabilityProvider(
     <details>
       <summary>
         <code>{name}</code>: interface:{" "}
-        <code>{capabilityProvider.interface.name}</code>
+        <code>{capabilityProvider.interface.name}</code>, active capability
         provider: <code>{capabilityProvider.name}</code>
       </summary>
       interface description: {capabilityProvider.interface.description}
@@ -162,6 +162,13 @@ function renderCapabilityProviderSet(set: CapabilityProviderSet): DocumentNode {
           <li>{renderCapabilityProvider(name, provider)}</li>
         ))}
       </ul>
+      To change the active capability provider for a protection capability, use
+      the{" "}
+      <code>
+        !draupnir protections capability {"<"}protection name{">"} {"<"}
+        capability name{">"} {"<"}capability provider name{">"}
+      </code>{" "}
+      command.
     </fragment>
   );
 }

--- a/src/commands/ProtectionsShowCommand.tsx
+++ b/src/commands/ProtectionsShowCommand.tsx
@@ -137,16 +137,25 @@ function renderCapabilityProvider(
   return (
     <details>
       <summary>
-        <code>{name}</code>: interface:{" "}
+        capability name: <code>{name}</code>, interface:{" "}
         <code>{capabilityProvider.interface.name}</code>, active capability
         provider: <code>{capabilityProvider.name}</code>
       </summary>
       interface description: {capabilityProvider.interface.description}
-      <h4>compatible capabilities:</h4>
+      <h4>
+        compatible capability providers for{" "}
+        <code>{capabilityProvider.interface.name}</code>:
+      </h4>
       <ul>
         {compatibleProviders.map((capability) => (
           <li>
-            <code>{capability.name}</code> - {capability.description}
+            <code>{capability.name}</code>
+            {capability === capabilityProvider ? (
+              <fragment> (active)</fragment>
+            ) : (
+              <fragment></fragment>
+            )}{" "}
+            - {capability.description}
           </li>
         ))}
       </ul>

--- a/yarn.lock
+++ b/yarn.lock
@@ -2593,18 +2593,18 @@ matrix-appservice@^2.0.0:
     request-promise "^4.2.6"
     sanitize-html "^2.11.0"
 
-"matrix-protection-suite-for-matrix-bot-sdk@npm:@gnuxie/matrix-protection-suite-for-matrix-bot-sdk@2.7.0":
-  version "2.7.0"
-  resolved "https://registry.yarnpkg.com/@gnuxie/matrix-protection-suite-for-matrix-bot-sdk/-/matrix-protection-suite-for-matrix-bot-sdk-2.7.0.tgz#82e3b053033d635ecdceab034c5548640bbe2332"
-  integrity sha512-Om+2CSojGJFqGnC9S7W9OXfccmI288nH93DACESRBjrlqVUO6mkdNSk789s1UTW5LIqZ3bjiC72F3STDASTdfg==
+"matrix-protection-suite-for-matrix-bot-sdk@npm:@gnuxie/matrix-protection-suite-for-matrix-bot-sdk@2.8.0":
+  version "2.8.0"
+  resolved "https://registry.yarnpkg.com/@gnuxie/matrix-protection-suite-for-matrix-bot-sdk/-/matrix-protection-suite-for-matrix-bot-sdk-2.8.0.tgz#a493e4ddfcff6c38486d62c14fa5fa7b0ac757f6"
+  integrity sha512-2J4t/ypFMXUCca7uz8e7Ha2f32jI6uX2mVyFKVI2kXVGUPQJm9aSh1MiOhiHHsG7zWv8erMeeCV2pmz5ms61hA==
   dependencies:
     "@gnuxie/typescript-result" "^1.0.0"
     await-lock "^2.2.2"
 
-"matrix-protection-suite@npm:@gnuxie/matrix-protection-suite@2.7.0":
-  version "2.7.0"
-  resolved "https://registry.yarnpkg.com/@gnuxie/matrix-protection-suite/-/matrix-protection-suite-2.7.0.tgz#953f89e3b02fd9b9edb21f0901f1ed22a2f41f48"
-  integrity sha512-ZTbz5t1Gh0Yxx+9+7EUp51HfBaccTazSpLKNPQDmjgjoVo6PT3da0CfTvGJR11EqLlBMey/D0zV418ajxjixrw==
+"matrix-protection-suite@npm:@gnuxie/matrix-protection-suite@2.8.0":
+  version "2.8.0"
+  resolved "https://registry.yarnpkg.com/@gnuxie/matrix-protection-suite/-/matrix-protection-suite-2.8.0.tgz#795fee15bbc4c7bc1273e06bff99f776f75fdfb9"
+  integrity sha512-UEnzkCjlqIXUCEPjqI3BIIxIY3WiOxkNat/lnKYfWpdRtfjYoMZUQngO0JujixFE0ec7d6EuYgtfk6A4skrP3Q==
   dependencies:
     "@gnuxie/typescript-result" "^1.0.0"
     await-lock "^2.2.2"


### PR DESCRIPTION
Currently looks like this, we just don't have alternative capabilities yet: 
![image](https://github.com/user-attachments/assets/24c1040c-54df-4895-b8b7-37d261254bf9)


