### PR TITLE
Address #746 and a small SQLite optimization.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,6 +23,8 @@ COPY --from=build-stage /tmp/src/package.json /
 
 ENV NODE_ENV=production
 ENV NODE_CONFIG_DIR=/data/config
+# Set SQLite's temporary directory. See #746 for context.
+ENV SQLITE_TMPDIR=/data
 
 CMD ["bot"]
 ENTRYPOINT ["./draupnir-entrypoint.sh"]


### PR DESCRIPTION
Explicitly set the `temp_store` pragma to `file` instead of `memory` after deciding to place temporary files in `/data` to keep RAM usage down while addressing #746.

Added a helper function to automatically "flatten" transactions when you don't need SAVEPOINTs to avoid unnecessary temporary files.