### PR TITLE
Add BlockInvitationOnServer protection.

### DIFF
--- a/src/protections/BlockInvitationsOnServerProtection.tsx
+++ b/src/protections/BlockInvitationsOnServerProtection.tsx
@@ -1,0 +1,172 @@
+// SPDX-FileCopyrightText: 2025 Gnuxie <Gnuxie@protonmail.com>
+//
+// SPDX-License-Identifier: AFL-3.0
+
+import {
+  AbstractProtection,
+  describeProtection,
+  Logger,
+  PolicyRuleType,
+  ProtectedRoomsSet,
+  Protection,
+  ProtectionDescription,
+  Recommendation,
+  UnknownConfig,
+  WatchedPolicyRooms,
+} from "matrix-protection-suite";
+import { BlockingCallback } from "../webapis/SynapseHTTPAntispam/SpamCheckEndpointPluginManager";
+import { UserMayInviteListenerArguments } from "../webapis/SynapseHTTPAntispam/UserMayInviteEndpoint";
+import { createHash } from "crypto";
+import {
+  MatrixGlob,
+  userServerName,
+} from "@the-draupnir-project/matrix-basic-types";
+import { SynapseHttpAntispam } from "../webapis/SynapseHTTPAntispam/SynapseHttpAntispam";
+import { Draupnir } from "../Draupnir";
+import { Ok, ResultError } from "@gnuxie/typescript-result";
+
+const log = new Logger("SynapseHTTPUserMayInvite");
+
+export class SynapseHTTPUserMayInvite {
+  private readonly synapseHTTPCallback = (
+    function (this: SynapseHTTPUserMayInvite, { inviter: sender, room_id }) {
+      const userHash = createHash("sha256")
+        .update(sender, "utf8")
+        .digest("base64");
+      const serverHash = createHash("sha256")
+        .update(userServerName(sender), "utf8")
+        .digest("base64");
+      // We only want to block user invites that with recommendation Ban
+      // when they match the automaticRedactReasons.
+      const matchingUserPolicy = [
+        ...this.watchedPolicyRooms.currentRevision.allRulesMatchingEntity(
+          sender,
+          {}
+        ),
+        ...this.watchedPolicyRooms.currentRevision.findRulesMatchingHash(
+          userHash,
+          "sha256",
+          { type: PolicyRuleType.User }
+        ),
+      ].find(
+        (policy) =>
+          policy.recommendation === Recommendation.Takedown ||
+          (policy.recommendation === Recommendation.Ban &&
+            this.automaticRedactionReasons.some((reason) =>
+              reason.test(policy.reason ?? "<no reason supplied>")
+            ))
+      );
+      const matchingServerOrRoomPolicy = [
+        ...this.watchedPolicyRooms.currentRevision.allRulesMatchingEntity(
+          userServerName(sender),
+          {}
+        ),
+        ...this.watchedPolicyRooms.currentRevision.findRulesMatchingHash(
+          serverHash,
+          "sha256",
+          { type: PolicyRuleType.Server }
+        ),
+        ...this.watchedPolicyRooms.currentRevision.allRulesMatchingEntity(
+          room_id,
+          {}
+        ),
+      ].find(
+        (policy) =>
+          policy.recommendation === Recommendation.Takedown ||
+          policy.recommendation === Recommendation.Ban
+      );
+      if (
+        matchingUserPolicy !== undefined ||
+        matchingServerOrRoomPolicy !== undefined
+      ) {
+        log.debug(
+          `Blocking an invitation from ${sender}`,
+          matchingServerOrRoomPolicy
+        );
+        return Promise.resolve({
+          errcode: "M_FORBIDDEN",
+          error: "You are not allowed to send invitations to this homeserver",
+        });
+      } else {
+        return Promise.resolve("NOT_SPAM");
+      }
+    } satisfies BlockingCallback<UserMayInviteListenerArguments>
+  ).bind(this);
+
+  private automaticRedactionReasons: MatrixGlob[] = [];
+  public constructor(
+    private readonly watchedPolicyRooms: WatchedPolicyRooms,
+    automaticallyRedactForReasons: string[],
+    private readonly synapseHTTPAntispam: SynapseHttpAntispam
+  ) {
+    for (const reason of automaticallyRedactForReasons) {
+      this.automaticRedactionReasons.push(new MatrixGlob(reason.toLowerCase()));
+    }
+    synapseHTTPAntispam.userMayInviteHandles.registerBlockingHandle(
+      this.synapseHTTPCallback
+    );
+  }
+
+  unregisterListeners(): void {
+    this.synapseHTTPAntispam.userMayInviteHandles.unregisterHandle(
+      this.synapseHTTPCallback
+    );
+  }
+}
+
+type BlockInvitationsOnServerProtectionCapabilities = Record<never, never>;
+
+type BlockInvitationsOnServerProtectionDescription = ProtectionDescription<
+  Draupnir,
+  UnknownConfig,
+  BlockInvitationsOnServerProtectionCapabilities
+>;
+
+export class BlockInvitationsOnServerProtection
+  extends AbstractProtection<BlockInvitationsOnServerProtectionDescription>
+  implements Protection<BlockInvitationsOnServerProtectionDescription>
+{
+  private readonly userMayInvite: SynapseHTTPUserMayInvite;
+  public constructor(
+    description: BlockInvitationsOnServerProtectionDescription,
+    capabilities: BlockInvitationsOnServerProtectionCapabilities,
+    protectedRoomsSet: ProtectedRoomsSet,
+    automaticallyRedactForReasons: string[],
+    synapseHTTPAntispam: SynapseHttpAntispam
+  ) {
+    super(description, capabilities, protectedRoomsSet, {});
+    this.userMayInvite = new SynapseHTTPUserMayInvite(
+      protectedRoomsSet.watchedPolicyRooms,
+      automaticallyRedactForReasons,
+      synapseHTTPAntispam
+    );
+  }
+
+  handleProtectionDisable(): void {
+    this.userMayInvite.unregisterListeners();
+  }
+}
+
+describeProtection<BlockInvitationsOnServerProtectionCapabilities, Draupnir>({
+  name: BlockInvitationsOnServerProtection.name,
+  description:
+    "Blocks invitations from users marked as takedown or have bans matching the the configured automaticallyRedactForReasons",
+  capabilityInterfaces: {},
+  defaultCapabilities: {},
+  factory(description, protectedRoomsSet, draupnir, capabilities, _settings) {
+    if (draupnir.synapseHTTPAntispam === undefined) {
+      return ResultError.Result(
+        "This protection requires synapse-http-antispam to be enabled"
+      );
+    }
+    return Ok(
+      new BlockInvitationsOnServerProtection(
+        description,
+        capabilities,
+        protectedRoomsSet,
+        draupnir.config.automaticallyRedactForReasons,
+        draupnir.synapseHTTPAntispam
+      )
+    );
+  },
+});

--- a/test/integration/protections/BlockInvitationsOnServerTest.ts
+++ b/test/integration/protections/BlockInvitationsOnServerTest.ts
@@ -1,0 +1,103 @@
+// SPDX-FileCopyrightText: 2025 Gnuxie <Gnuxie@protonmail.com>
+//
+// SPDX-License-Identifier: AFL-3.0
+
+import {
+  MatrixRoomReference,
+  StringRoomID,
+  StringUserID,
+} from "@the-draupnir-project/matrix-basic-types";
+import { Draupnir } from "../../../src/Draupnir";
+import { DraupnirTestContext } from "../mjolnirSetupUtils";
+import { newTestUser } from "../clientHelper";
+import { BlockInvitationsOnServerProtection } from "../../../src/protections/BlockInvitationsOnServerProtection";
+import expect from "expect";
+import { resultifyBotSDKRequestError } from "matrix-protection-suite-for-matrix-bot-sdk";
+import { isOk, MatrixException, Ok } from "matrix-protection-suite";
+import { MatrixError } from "matrix-bot-sdk";
+
+async function createWatchedPolicyRoom(
+  draupnir: Draupnir
+): Promise<StringRoomID> {
+  const policyRoomID = (await draupnir.client.createRoom({
+    preset: "public_chat",
+  })) as StringRoomID;
+  (
+    await draupnir.protectedRoomsSet.watchedPolicyRooms.watchPolicyRoomDirectly(
+      MatrixRoomReference.fromRoomID(policyRoomID)
+    )
+  ).expect("Should be able to watch the new policy room");
+  return policyRoomID;
+}
+
+describe("RoomTakedownProtectionTest", function () {
+  it("Will takedown a room that is added to the policy list", async function (
+    this: DraupnirTestContext
+  ) {
+    const draupnir = this.draupnir;
+    if (draupnir === undefined) {
+      throw new TypeError(`setup didn't run properly`);
+    }
+    const moderator = await newTestUser(this.config.homeserverUrl, {
+      name: { contains: "moderator" },
+    });
+    const moderatorUserID = StringUserID(await moderator.getUserId());
+    const takedownTarget = await newTestUser(this.config.homeserverUrl, {
+      name: { contains: "takedown-target" },
+    });
+    const takedownTargetUserID = StringUserID(await takedownTarget.getUserId());
+    const takedownTargetRoomID = StringRoomID(
+      await takedownTarget.createRoom({
+        preset: "public_chat",
+      })
+    );
+    await moderator.joinRoom(draupnir.managementRoomID);
+    const policyRoom = await createWatchedPolicyRoom(draupnir);
+    (
+      await draupnir.sendTextCommand(
+        moderatorUserID,
+        `!draupnir protections enable ${BlockInvitationsOnServerProtection.name}`
+      )
+    ).expect("Should be able to enable the protection");
+    (
+      await draupnir.sendTextCommand(
+        moderatorUserID,
+        `!draupnir takedown ${takedownTargetUserID} ${policyRoom} --no-confirm`
+      )
+    ).expect("Should be able to create the policy targetting the dodgy user");
+
+    const invitationResult = await takedownTarget
+      .inviteUser(moderatorUserID, takedownTargetRoomID)
+      .then((_) => Ok(undefined), resultifyBotSDKRequestError);
+    if (isOk(invitationResult)) {
+      throw new TypeError(
+        "takendown users shouldn't be able to send invitations"
+      );
+    }
+    // I'm pretty sure there are different versions of this being used in the code base
+    // so instanceof fails :/ sucks balls mare
+    // https://github.com/the-draupnir-project/Draupnir/issues/760
+    // https://github.com/the-draupnir-project/Draupnir/issues/759
+    if (invitationResult.error instanceof MatrixException) {
+      expect(invitationResult.error.matrixErrorMessage).toBe(
+        "You are not allowed to send invitations to this homeserver"
+      );
+      expect(invitationResult.error.matrixErrorCode).toBe("M_FORBIDDEN");
+    } else {
+      const matrixError = invitationResult.error.exception as MatrixError;
+      expect(matrixError.error).toBe(
+        "You are not allowed to send invitations to this homeserver"
+      );
+      expect(matrixError.errcode).toBe("M_FORBIDDEN");
+
+      // now test that invitations can go through anyways
+      await moderator.joinRoom(takedownTargetRoomID);
+      await takedownTarget.setUserPowerLevel(
+        moderatorUserID,
+        takedownTargetRoomID,
+        100
+      );
+      await moderator.inviteUser(draupnir.clientUserID, takedownTargetRoomID);
+    }
+  } as unknown as Mocha.AsyncFunc);
+});


### PR DESCRIPTION
This protection uses synapse-http-antispam to block invitations to users marked with `org.matrix.msc.4204.takedown` or if they are marked with `automaticallyRedactReasons`. 