### PR TITLE
Ensure we run draupnir not as root in Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,6 +15,10 @@ RUN cd /tmp/src \
     && yarn install --frozen-lockfile --production --network-timeout 100000
 
 FROM node:20-slim as final-stage
+
+# We dont want to be root when running so we create a draupnir user
+USER 1000:1000
+
 COPY --from=build-stage /tmp/src/version.txt version.txt
 COPY --from=build-stage /tmp/src/lib/ /draupnir/
 COPY --from=build-stage /tmp/src/node_modules /node_modules


### PR DESCRIPTION
THIS IS A POSSIBLY BREAKING CHANGE!

This changes the user in docker to the 1000 UID and 1000 GID. Allowing it to run with less and least permissions.
However this also means that potentially the storage volumes are owned by root and not accessible therefore. Users will have to manually fix this. How to migrate will depend on the env.