### PR TITLE
update to interface-manager 4.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "@gnuxie/typescript-result": "^1.0.0",
     "@sentry/node": "^7.17.2",
     "@sinclair/typebox": "0.34.13",
-    "@the-draupnir-project/interface-manager": "4.0.2",
+    "@the-draupnir-project/interface-manager": "4.1.0",
     "@the-draupnir-project/matrix-basic-types": "1.3.0",
     "better-sqlite3": "^9.4.3",
     "body-parser": "^1.20.2",

--- a/src/commands/DraupnirCommandTable.ts
+++ b/src/commands/DraupnirCommandTable.ts
@@ -14,12 +14,14 @@ import {
   StringFromMatrixRoomIDTranslator,
   StringFromMatrixUserIDTranslator,
   StringFromNumberTranslator,
+  StringfromBooleanTranslator,
 } from "@the-draupnir-project/interface-manager";
 
 export const DraupnirTopLevelCommands = new StandardCommandTable(
   "draupnir top level"
 )
   .internPresentationTypeTranslator(StringFromNumberTranslator)
+  .internPresentationTypeTranslator(StringfromBooleanTranslator)
   .internPresentationTypeTranslator(StringFromMatrixRoomIDTranslator)
   .internPresentationTypeTranslator(StringFromMatrixRoomAliasTranslator)
   .internPresentationTypeTranslator(StringFromMatrixUserIDTranslator)

--- a/src/safemode/commands/SafeModeCommands.tsx
+++ b/src/safemode/commands/SafeModeCommands.tsx
@@ -4,6 +4,7 @@
 
 import {
   StandardCommandTable,
+  StringfromBooleanTranslator,
   StringFromMatrixEventReferenceTranslator,
   StringFromMatrixRoomAliasTranslator,
   StringFromMatrixRoomIDTranslator,
@@ -17,6 +18,7 @@ import { SafeModeRecoverCommand } from "./RecoverCommand";
 
 export const SafeModeCommands = new StandardCommandTable("safe mode")
   .internPresentationTypeTranslator(StringFromNumberTranslator)
+  .internPresentationTypeTranslator(StringfromBooleanTranslator)
   .internPresentationTypeTranslator(StringFromMatrixRoomIDTranslator)
   .internPresentationTypeTranslator(StringFromMatrixRoomAliasTranslator)
   .internPresentationTypeTranslator(StringFromMatrixUserIDTranslator)

--- a/yarn.lock
+++ b/yarn.lock
@@ -311,10 +311,10 @@
   resolved "https://registry.yarnpkg.com/@sinclair/typebox/-/typebox-0.27.8.tgz#6667fac16c436b5434a387a34dedb013198f6e6e"
   integrity sha512-+Fj43pSMwJs4KRrH/938Uf+uAELIgVBmQzg/q1YG10djyfA3TnrU8N8XzqCh/okZdszqBQTZf96idMfE5lnwTA==
 
-"@the-draupnir-project/interface-manager@4.0.2":
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/@the-draupnir-project/interface-manager/-/interface-manager-4.0.2.tgz#77f5ea907f73676635f6b515f907ff7f2ebdcc29"
-  integrity sha512-CV+BtJBUAa7alXU9AZPI0h6SNdQRAQUNRYJepgCJdV87AFkme99Z2M8q6War/FB2P36MDfFo123v91OIECwuww==
+"@the-draupnir-project/interface-manager@4.1.0":
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/@the-draupnir-project/interface-manager/-/interface-manager-4.1.0.tgz#bc5ca52e4d042f73c832b2069a625fff0b7ef193"
+  integrity sha512-sv+G38Ua4rB/MOtz6keE9TI9PfhlpRlCiBeQhbqkesAJ5h5p8ZfeVRpUFTwuk6WB3NDV40QJZpOBDo9YkE/P5g==
   dependencies:
     "@gnuxie/super-cool-stream" "^0.2.1"
     "@gnuxie/typescript-result" "^1.0.0"


### PR DESCRIPTION
Fixes a tonne of shite mare.
Importantly https://github.com/the-draupnir-project/Draupnir/issues/845. And something @ll-SKY-ll mentioned in the draupnir room regarding the new MentionLimitProtection.

Added

- Quote syntax to quote strings.
- Boolean presentation type and translator to string.

Fixed

- Added a pathway to create negative integers.