### PR TITLE
Improve room shutdown flows.

### DIFF
--- a/src/capabilities/SynapseAdminRoomTakedown/SynapseAdminRoomTakedown.ts
+++ b/src/capabilities/SynapseAdminRoomTakedown/SynapseAdminRoomTakedown.ts
@@ -79,6 +79,9 @@ export class SynapseAdminRoomTakedownCapability
       details = detailsResponse.ok;
     }
     log.debug("Taking down room", roomID);
+    // we use delte V1 because clients do not pick up the user's own leave event
+    // in V2 and i don't know why.
+    // That is very important in the case of stuck invitations.
     const takedownResult = await this.adminClient.deleteRoom(roomID, {
       block: true,
       purge: true,

--- a/test/integration/commands/shutdownCommandTest.ts
+++ b/test/integration/commands/shutdownCommandTest.ts
@@ -59,22 +59,7 @@ describe("Test: shutdown command", function () {
       );
     });
 
-    const reply2 = new Promise((resolve) => {
-      draupnirMatrixClient.on("room.event", (roomId, event) => {
-        if (
-          roomId !== draupnir.managementRoomID &&
-          roomId !== badRoom &&
-          event?.type === "m.room.message" &&
-          event.sender === draupnir.clientUserID &&
-          event.content?.body === "closure test"
-        ) {
-          resolve(event);
-        }
-      });
-    });
-
     await reply1;
-    await reply2;
 
     await assert.rejects(client.joinRoom(badRoom), (e: MatrixError) => {
       assert.equal(e.statusCode, 403);


### PR DESCRIPTION
- The shutdown command now has a `--notify` option for whether to send the violation notification.
- We use shutdown V1 because V2 doesn't propagate leave events to clients properly. Which sucks.