### PR TITLE
Takedown improvements

### DIFF
--- a/src/protections/BlockInvitationsOnServerProtection.tsx
+++ b/src/protections/BlockInvitationsOnServerProtection.tsx
@@ -36,8 +36,10 @@ export class SynapseHTTPUserMayInvite {
       const serverHash = createHash("sha256")
         .update(userServerName(sender), "utf8")
         .digest("base64");
-      // We only want to block user invites that with recommendation Ban
-      // when they match the automaticRedactReasons.
+      // We only want to block the invitation with user policies with recommendation Ban
+      // when they match the automaticRedactReasons. This is so they can still appeal
+      // being banned in COC use cases.
+      // Server policies are fine to be used to derive the block.
       const matchingUserPolicy = [
         ...this.watchedPolicyRooms.currentRevision.allRulesMatchingEntity(
           sender,

--- a/src/protections/RoomTakedown/RoomTakedownProtection.ts
+++ b/src/protections/RoomTakedown/RoomTakedownProtection.ts
@@ -57,7 +57,7 @@ const RoomTakedownProtectionSettings = Type.Object(
       })
     ),
     discoveryNotificationEnabled: Type.Boolean({
-      default: true,
+      default: false,
       description:
         "Wether to send notifications for newly discovered rooms from the homerserver.",
     }),


### PR DESCRIPTION
- disable room discovery by default while we work out how to pipe it into a new room
- show status of takedown protections in the takedown command
- clarify a comment about the implementation of blocking invintations

We really need to figure out how to let protections put all their output into a room.