### PR TITLE
Attempt to allow Draupnir to use room V12.

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "@sentry/node": "^7.17.2",
     "@sinclair/typebox": "0.34.13",
     "@the-draupnir-project/interface-manager": "4.1.0",
-    "@the-draupnir-project/matrix-basic-types": "1.3.0",
+    "@the-draupnir-project/matrix-basic-types": "1.4.0",
     "@the-draupnir-project/mps-interface-adaptor": "^0.4.1",
     "better-sqlite3": "^9.4.3",
     "body-parser": "^1.20.2",
@@ -71,7 +71,7 @@
   "overrides": {
     "matrix-bot-sdk": "$@vector-im/matrix-bot-sdk",
     "@vector-im/matrix-bot-sdk": "npm:@vector-im/matrix-bot-sdk@^0.7.1-element.6",
-    "@the-draupnir-project/matrix-basic-types": "@the-draupnir-project/matrix-basic-types@1.2.0",
+    "@the-draupnir-project/matrix-basic-types": "$the-draupnir-project/matrix-basic-types",
     "matrix-protection-suite": "$matrix-protection-suite"
   },
   "engines": {

--- a/src/backingstore/better-sqlite3/HashStore.ts
+++ b/src/backingstore/better-sqlite3/HashStore.ts
@@ -9,7 +9,6 @@
 
 import { isError, Ok, Result } from "@gnuxie/typescript-result";
 import {
-  roomIDServerName,
   StringRoomID,
   StringServerName,
   StringUserID,
@@ -323,8 +322,7 @@ export class SqliteHashReversalStore
       (room_id: StringRoomID, sha256) => ({ room_id, sha256 }),
       (roomRecords) => {
         this.emit("ReversedHashes", roomRecords, [], []);
-      },
-      (roomRecord) => roomIDServerName(roomRecord.room_id)
+      }
     );
   }
 

--- a/src/protections/RoomTakedown/DiscoveredRoomStore.ts
+++ b/src/protections/RoomTakedown/DiscoveredRoomStore.ts
@@ -4,8 +4,8 @@
 
 import { isError, Ok, Result } from "@gnuxie/typescript-result";
 import {
-  roomIDServerName,
   StringRoomID,
+  userServerName,
 } from "@the-draupnir-project/matrix-basic-types";
 import {
   Logger,
@@ -79,7 +79,7 @@ export class StandardDiscoveredRoomStore
       const storeResult = await this.hashStore.storeRoomIdentification({
         creator: details.creator,
         roomID: details.room_id,
-        server: roomIDServerName(details.room_id),
+        server: userServerName(details.creator),
       });
       if (isError(storeResult)) {
         log.error(

--- a/yarn.lock
+++ b/yarn.lock
@@ -319,10 +319,10 @@
     "@gnuxie/super-cool-stream" "^0.2.1"
     "@gnuxie/typescript-result" "^1.0.0"
 
-"@the-draupnir-project/matrix-basic-types@1.3.0":
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/@the-draupnir-project/matrix-basic-types/-/matrix-basic-types-1.3.0.tgz#02fa9bd75eeed778a57da0844447feca3a4c663c"
-  integrity sha512-WkUD7cqs9qFr1NQZiJWxa+/1trWrhQqv8SbPxrMLRKv1LMm93ELeguROP470kHNWHrCkVcKmYQVc4uC2Yup+EQ==
+"@the-draupnir-project/matrix-basic-types@1.4.0":
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/@the-draupnir-project/matrix-basic-types/-/matrix-basic-types-1.4.0.tgz#18fcfc7561ad495f4868ef4298131a3e20e7d946"
+  integrity sha512-nKK9vmAXh87VwaANvlNlUaq/rIu50VcdRXfoPJB99RqY4dt6iXRu/1b8mQJ5rDCK4yun/4IyGexw6FVQAqT58Q==
   dependencies:
     "@gnuxie/typescript-result" "^1.0.0"
     glob-to-regexp "^0.4.1"


### PR DESCRIPTION
- Updated to matrix-basic-types 1.4.0 which changes the regex validating room ids.

- Changed the package override so that all dependencies use matrix-basic-types 1.4.0, including the matrix-protection-suite.

- Removed code that tries to store details about discovered rooms in the room takdedown protection. These were unreliable for so many reasons and also are now broken given the room origin cannot be extracted from the room id. Details for why this is can be found in the reviews of https://github.com/matrix-org/matrix-spec-proposals/pull/4291.