### PR TITLE
Add a protection to automatically protect replacement_rooms when protected rooms are tombstoned.

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "jsdom": "^24.0.0",
     "matrix-appservice-bridge": "^10.3.1",
     "matrix-bot-sdk": "npm:@vector-im/matrix-bot-sdk@^0.7.1-element.6",
-    "matrix-protection-suite": "npm:@gnuxie/matrix-protection-suite@3.8.0",
+    "matrix-protection-suite": "npm:@gnuxie/matrix-protection-suite@3.9.0",
     "matrix-protection-suite-for-matrix-bot-sdk": "npm:@gnuxie/matrix-protection-suite-for-matrix-bot-sdk@3.8.0",
     "pg": "^8.8.0",
     "yaml": "^2.3.2"

--- a/src/protections/ProtectedRooms/ProtectReplacementRooms.tsx
+++ b/src/protections/ProtectedRooms/ProtectReplacementRooms.tsx
@@ -1,0 +1,161 @@
+// SPDX-FileCopyrightText: 2025 Gnuxie <Gnuxie@protonmail.com>
+//
+// SPDX-License-Identifier: AFL-3.0
+
+import { isError, Ok, Result, ResultError } from "@gnuxie/typescript-result";
+import {
+  MatrixRoomID,
+  MatrixRoomReference,
+  StringRoomID,
+  userServerName,
+} from "@the-draupnir-project/matrix-basic-types";
+import {
+  renderDetailsNotice,
+  renderElaborationTrail,
+  renderExceptionTrail,
+  renderOutcome,
+  renderRoomPill,
+  sendMatrixEventsFromDeadDocument,
+} from "@the-draupnir-project/mps-interface-adaptor";
+import {
+  Logger,
+  ProtectedRoomsManager,
+  RoomJoiner,
+  RoomMessageSender,
+  StateChange,
+  StateChangeType,
+  Task,
+  TombstoneEvent,
+  Value,
+} from "matrix-protection-suite";
+import { DeadDocumentJSX } from "@the-draupnir-project/interface-manager";
+
+const log = new Logger("ProtectReplacementRooms");
+
+export class ProtectReplacementRooms {
+  public constructor(
+    private readonly managementRoomID: StringRoomID,
+    private readonly roomJoiner: RoomJoiner,
+    private readonly roomMessageSender: RoomMessageSender,
+    private readonly protectedRoomsManager: ProtectedRoomsManager
+  ) {
+    // nothing to do.
+  }
+
+  handleRoomStateChange(changes: StateChange[]): void {
+    for (const change of changes) {
+      if (change.eventType !== "m.room.tombstone") {
+        continue;
+      }
+      switch (change.changeType) {
+        case StateChangeType.Introduced:
+        case StateChangeType.PartiallyRedacted:
+        case StateChangeType.Reintroduced:
+        case StateChangeType.SupersededContent:
+          break;
+        default:
+          continue;
+      }
+      if (Value.Check(TombstoneEvent, change.state)) {
+        void Task(this.handleTombstone(change.state), {
+          log,
+        });
+      }
+    }
+  }
+
+  private async protectReplacementRoom(
+    replacementRoom: MatrixRoomID
+  ): Promise<Result<void>> {
+    const joinResult = await this.roomJoiner.joinRoom(replacementRoom);
+    if (isError(joinResult)) {
+      return joinResult.elaborate(
+        "Failed to join replacement room while following a room upgrade"
+      );
+    }
+    const protectResult =
+      await this.protectedRoomsManager.addRoom(replacementRoom);
+    if (isError(protectResult)) {
+      return protectResult.elaborate(
+        "Failed to protect the replacement room while following a room upgrade"
+      );
+    }
+    return Ok(undefined);
+  }
+
+  private async notifyManagementRoomOfUpgrade(
+    event: TombstoneEvent,
+    replacementRoom: MatrixRoomID
+  ): Promise<Result<void>> {
+    return (await sendMatrixEventsFromDeadDocument(
+      this.roomMessageSender,
+      this.managementRoomID,
+      <root>
+        <h4>
+          The room{" "}
+          {renderRoomPill(MatrixRoomReference.fromRoomID(event.room_id))} has
+          been upgraded to {renderRoomPill(replacementRoom)} (
+          <code>{replacementRoom.toRoomIDOrAlias()}</code>)
+        </h4>
+        The replacement room is now protected.
+      </root>,
+      {}
+    )) as Result<void>;
+  }
+
+  private async reportRoomUpgradeError(
+    error: ResultError,
+    event: TombstoneEvent,
+    replacementRoom: MatrixRoomID
+  ): Promise<Result<void>> {
+    return (await sendMatrixEventsFromDeadDocument(
+      this.roomMessageSender,
+      this.managementRoomID,
+      <root>
+        <details>
+          <summary>
+            Failed to protect the replacement room{" "}
+            {renderRoomPill(replacementRoom)} (
+            {replacementRoom.toRoomIDOrAlias()}) after upgrading from{" "}
+            {renderRoomPill(MatrixRoomReference.fromRoomID(event.room_id))} -{" "}
+            {renderOutcome(false)}
+          </summary>
+          {error.mostRelevantElaboration}
+          {renderDetailsNotice(error)}
+          {renderElaborationTrail(error)}
+          {renderExceptionTrail(error)}
+        </details>
+      </root>,
+      {}
+    )) as Result<void>;
+  }
+
+  private async handleTombstone(event: TombstoneEvent): Promise<Result<void>> {
+    if (!this.protectedRoomsManager.isProtectedRoom(event.room_id)) {
+      return Ok(undefined);
+    }
+    if (event.content.replacement_room === undefined) {
+      // No replacement room specified, nothing to do.
+      return Ok(undefined);
+    }
+    const replacementRoom = new MatrixRoomID(event.content.replacement_room, [
+      userServerName(event.sender),
+    ]);
+    const upgradeResult = await this.protectReplacementRoom(replacementRoom);
+    if (isError(upgradeResult)) {
+      void Task(
+        this.reportRoomUpgradeError(
+          upgradeResult.error,
+          event,
+          replacementRoom
+        ),
+        { log }
+      );
+    } else {
+      void Task(this.notifyManagementRoomOfUpgrade(event, replacementRoom), {
+        log,
+      });
+    }
+    return upgradeResult;
+  }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2606,10 +2606,10 @@ matrix-appservice@^2.0.0:
     "@gnuxie/typescript-result" "^1.0.0"
     await-lock "^2.2.2"
 
-"matrix-protection-suite@npm:@gnuxie/matrix-protection-suite@3.8.0":
-  version "3.8.0"
-  resolved "https://registry.yarnpkg.com/@gnuxie/matrix-protection-suite/-/matrix-protection-suite-3.8.0.tgz#8e6370381d3bed0578624a3ba8c2ca3df7899024"
-  integrity sha512-R+6om4Mrf2evEaYZWzkLukjMdsyZv+0xyslCoQ0exd7i3LiAQ6TbcMyML7FD9UFxtPBHCO3my6OyWKCFtt5fQA==
+"matrix-protection-suite@npm:@gnuxie/matrix-protection-suite@3.9.0":
+  version "3.9.0"
+  resolved "https://registry.yarnpkg.com/@gnuxie/matrix-protection-suite/-/matrix-protection-suite-3.9.0.tgz#35b8889cf110d703858d05f0d8a7d93ff547071b"
+  integrity sha512-6hVsvt5FeNZwYyoyi5N2gbKWaoWMCCAO2vrsG3Rg52srxbAPm6b2SyZ0U7TsfkybLG1L/sARYWlsJQaA5LBf9g==
   dependencies:
     "@gnuxie/typescript-result" "^1.0.0"
     await-lock "^2.2.2"


### PR DESCRIPTION
Closes https://github.com/the-draupnir-project/planning/issues/46.