### PR TITLE
Fix flakey BlockInvitationsOnServer test case.

### DIFF
--- a/test/integration/protections/BlockInvitationsOnServerTest.ts
+++ b/test/integration/protections/BlockInvitationsOnServerTest.ts
@@ -66,6 +66,12 @@ describe("RoomTakedownProtectionTest", function () {
       )
     ).expect("Should be able to create the policy targetting the dodgy user");
 
+    // We have to wait here for the policy to come down sync and for the internal
+    // models to process and update it.
+    // There doesn't seem to be a reliable way in concept to update the model.
+    // where we could avoid doing this.
+    await new Promise((resolve) => setTimeout(resolve, 1000));
+
     const invitationResult = await takedownTarget
       .inviteUser(moderatorUserID, takedownTargetRoomID)
       .then((_) => Ok(undefined), resultifyBotSDKRequestError);


### PR DESCRIPTION
Wait for the new takedown policy to come down `/sync` before testing the protection can block the takendown user.

There doesn't seem to be a way conceptually to avoid this. I would not be comfortable with injecting a fake event into the model and we'd probably have a nightmare creating that concept.

See https://github.com/the-draupnir-project/Draupnir/pull/930#issuecomment-3179386744.