### PR TITLE
Fix policy room creation in V12 rooms.

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "matrix-appservice-bridge": "^10.3.1",
     "matrix-bot-sdk": "npm:@vector-im/matrix-bot-sdk@^0.7.1-element.6",
     "matrix-protection-suite": "npm:@gnuxie/matrix-protection-suite@3.10.0",
-    "matrix-protection-suite-for-matrix-bot-sdk": "npm:@gnuxie/matrix-protection-suite-for-matrix-bot-sdk@3.8.0",
+    "matrix-protection-suite-for-matrix-bot-sdk": "npm:@gnuxie/matrix-protection-suite-for-matrix-bot-sdk@3.10.0",
     "pg": "^8.8.0",
     "yaml": "^2.3.2"
   },

--- a/src/appservice/AppServiceDraupnirManager.ts
+++ b/src/appservice/AppServiceDraupnirManager.ts
@@ -457,7 +457,7 @@ export async function makeManagementRoom(
     );
   }
   const isV12OrAboveDefault =
-    capabilities.ok.capabilities["m.room_versions"].default >= "12";
+    parseInt(capabilities.ok.capabilities["m.room_versions"].default) >= 12;
   return await roomCreator.createRoom({
     preset: "private_chat",
     invite: [requestingUserID],

--- a/yarn.lock
+++ b/yarn.lock
@@ -2598,10 +2598,10 @@ matrix-appservice@^2.0.0:
     request-promise "^4.2.6"
     sanitize-html "^2.11.0"
 
-"matrix-protection-suite-for-matrix-bot-sdk@npm:@gnuxie/matrix-protection-suite-for-matrix-bot-sdk@3.8.0":
-  version "3.8.0"
-  resolved "https://registry.yarnpkg.com/@gnuxie/matrix-protection-suite-for-matrix-bot-sdk/-/matrix-protection-suite-for-matrix-bot-sdk-3.8.0.tgz#d47c87154c41f81816feb740b460696f2e141820"
-  integrity sha512-P1YkVGVbcCKfQlPMKDY72gm9u/XJ4Hq/6NTTU2rp7/aE7erP9UiZWKn5b+gglSS2SlcIxnbSFRohNKpvGHcptA==
+"matrix-protection-suite-for-matrix-bot-sdk@npm:@gnuxie/matrix-protection-suite-for-matrix-bot-sdk@3.10.0":
+  version "3.10.0"
+  resolved "https://registry.yarnpkg.com/@gnuxie/matrix-protection-suite-for-matrix-bot-sdk/-/matrix-protection-suite-for-matrix-bot-sdk-3.10.0.tgz#115ed98ca3634dfe32d2a98db727e2c709ff4adb"
+  integrity sha512-zAU/Dy3DBFgOtNWsP3ybwvVdXQjO3ro58ETn+F3BMln1WTGzTbZvvrMrL5F2ooD/uhy0XR4zjfw0Kh98/loFzw==
   dependencies:
     "@gnuxie/typescript-result" "^1.0.0"
     await-lock "^2.2.2"


### PR DESCRIPTION
It turns out that we got confused and thought we'd fixed policy room creation when we fixed management room creation.
Even though the PR description never claimed that. In any case it looks like we were not in a very present state of mind while making the change and managed to somehow rely on string comparison for room versions...

Follow up from: https://github.com/the-draupnir-project/Draupnir/pull/924