### PR TITLE
fix spurious error log line regarding room takedowns when the room ha…

### DIFF
--- a/src/protections/RoomTakedown/RoomTakedown.ts
+++ b/src/protections/RoomTakedown/RoomTakedown.ts
@@ -58,7 +58,9 @@ export class StandardRoomTakedown implements RoomTakedownService {
       return isRoomTakendownResult;
     }
     if (isRoomTakendownResult.ok) {
-      log.debug(`The room ${roomID} has already been taken down according to your homeserver`);
+      log.debug(
+        `The room ${roomID} has already been taken down according to your homeserver`
+      );
       return Ok(undefined);
     }
     const detailsResult = await this.takedownCapability.getRoomDetails(roomID);


### PR DESCRIPTION
…s already been taken down.

This is normal, and while generally the bot shouldn't attempt to take down the same rooms which succeeded in the past, there's no way of knowing that the room hasn't been unblocked by the synapse admin API while draupnir was offline. Because there's no endpoint to get only the blocked rooms, we have to attempt to block them all again, but what we can do is lower that from critical severity to debug, since it's not actually a fatal error at all.

https://github.com/the-draupnir-project/Draupnir/issues/993