### PR TITLE
Be more precise about licensing.

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -14,9 +14,10 @@ No single license applies to all files in this repository.
 
 ## Additional note
 
-This project is primarily developed under the Academic Free License 3.0 (AFL-3.0),
-but includes components under other permissive licenses, including Apache License 2.0.
+This project is primarily developed under the Academic Free License 3.0
+(AFL-3.0), with some components under Apache-2.0, and others under more
+permissive licenses such as MIT or 0BSD.
 
-When redistributing this project, you must comply with the terms of each applicable
-license. For Apache-2.0 components, this includes preserving copyright notices and
-any required NOTICE files, and including a copy of the Apache License 2.0.
+When redistributing Draupnir, you must comply with the terms of each applicable
+license. In practice, this primarily involves preserving license texts and any
+required NOTICE files for Apache-2.0 components.

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,22 @@
+# Licensing
+
+This file provides an overview of licensing in this repository.
+Individual license texts in the `LICENSES/` directory are authoritative.
+
+This repository contains software distributed under multiple open source licenses.
+
+The license for each file is indicated by its SPDX-License-Identifier where present,
+or otherwise a SPDX-License-Identifier within a REUSE.toml in the same filesystem
+directory. Packages also declare their license in their respective `package.json`
+files. The full license texts are available in the `LICENSES/` directory.
+
+No single license applies to all files in this repository.
+
+## Additional note
+
+This project is primarily developed under the Academic Free License 3.0 (AFL-3.0),
+but includes components under other permissive licenses, including Apache License 2.0.
+
+When redistributing this project, you must comply with the terms of each applicable
+license. For Apache-2.0 components, this includes preserving copyright notices and
+any required NOTICE files, and including a copy of the Apache License 2.0.

--- a/README.md
+++ b/README.md
@@ -198,6 +198,18 @@ Please see or
 but do not worry too much about following the guidance to the letter. And keep
 that in mind throughout.
 
+## License
+
+This distribution contains components under multiple licenses, including
+Apache-2.0 and AFL-3.0. See [LICENSE](./LICENSE) and LICENSES/ for details.
+
+This project is primarily developed under the Academic Free License 3.0
+(AFL-3.0), but includes components under other permissive licenses.
+
+When redistributing, you must comply with the terms of each applicable license.
+For Apache-2.0 components, this includes preserving copyright notices and any
+required NOTICE files, and including a copy of the Apache License 2.0.
+
 ## Supported by
 
 ### NLnet

--- a/README.md
+++ b/README.md
@@ -204,11 +204,12 @@ This distribution contains components under multiple licenses, including
 Apache-2.0 and AFL-3.0. See [LICENSE](./LICENSE) and LICENSES/ for details.
 
 This project is primarily developed under the Academic Free License 3.0
-(AFL-3.0), but includes components under other permissive licenses.
+(AFL-3.0), with some components under Apache-2.0, and others under more
+permissive licenses such as MIT or 0BSD.
 
-When redistributing, you must comply with the terms of each applicable license.
-For Apache-2.0 components, this includes preserving copyright notices and any
-required NOTICE files, and including a copy of the Apache License 2.0.
+When redistributing Draupnir, you must comply with the terms of each applicable
+license. In practice, this primarily involves preserving license texts and any
+required NOTICE files for Apache-2.0 components.
 
 ## Supported by
 

--- a/apps/draupnir/package.json
+++ b/apps/draupnir/package.json
@@ -5,7 +5,7 @@
   "main": "lib/index.js",
   "repository": "https://github.com/the-draupnir-project/Draupnir.git",
   "author": "Gnuxie",
-  "license": "AFL-3.0",
+  "license": "SEE LICENSE IN LICENSE",
   "private": true,
   "scripts": {
     "build": "tsc --project test/tsconfig.json && npm run build:assets",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "url": "git+https://github.com/the-draupnir-project/Draupnir.git"
   },
   "author": "Gnuxie",
-  "license": "AFL-3.0",
+  "license": "SEE LICENSE IN LICENSE",
   "bugs": {
     "url": "https://github.com/the-draupnir-project/Draupnir/issues"
   },


### PR DESCRIPTION
I've added a root LICENSE file describing the use of multiple licenses in the repository, especially given that it is now monorepo.

This does not change any licensing terms or introduce new requirements It makes the existing setup more explicit and easier to understand for users and downstream distributors. And reflects the existing REUSE compliant setup.