### PR TITLE
Remove filesystem news.

### DIFF
--- a/apps/draupnir/package.json
+++ b/apps/draupnir/package.json
@@ -9,7 +9,7 @@
   "private": true,
   "scripts": {
     "build": "tsc --project test/tsconfig.json && npm run build:assets",
-    "build:assets": "cp src/protections/DraupnirNews/news.json dist/protections/DraupnirNews/news.json && npm run describe-version && npm run describe-branch",
+    "build:assets": "npm run describe-version && npm run describe-branch",
     "describe-version": "(git describe > version.txt.tmp && mv version.txt.tmp version.txt) || true && rm -f version.txt.tmp",
     "describe-branch": "(git rev-parse --abbrev-ref HEAD > branch.txt.tmp && mv branch.txt.tmp branch.txt) || true && rm -f branch.txt.tmp",
     "harness-registration": "node dist/appservice/cli.js -r -u \"http://host.docker.internal:9000\" --enable-source-maps",

--- a/apps/draupnir/src/protections/DraupnirNews/DraupnirNews.tsx
+++ b/apps/draupnir/src/protections/DraupnirNews/DraupnirNews.tsx
@@ -1,9 +1,8 @@
-// SPDX-FileCopyrightText: 2025 Gnuxie <Gnuxie@protonmail.com>
+// SPDX-FileCopyrightText: 2025 - 2026 Gnuxie <Gnuxie@protonmail.com>
 //
 // SPDX-License-Identifier: AFL-3.0
 
-import { readFileSync } from "fs";
-import { isOk, Ok, Result } from "@gnuxie/typescript-result";
+import { Ok, Result } from "@gnuxie/typescript-result";
 import { Type } from "@sinclair/typebox";
 import {
   AbstractProtection,
@@ -25,13 +24,15 @@ import {
 } from "matrix-protection-suite";
 import { Draupnir } from "../../Draupnir";
 import { DraupnirProtection } from "../Protection";
-import path from "path";
 
 const log = new Logger("DraupnirNews");
 
 // TODO:
 // We should probably allow tagging these e.g. to assist making an automated system
 // for adding release news.
+// We can't use the news system directly for notifying about releases,
+// we'd have to use something that mutates a link to the changelog based
+// on the version provided in Draupnir, see https://github.com/the-draupnir-project/Draupnir/issues/1093.
 export type DraupnirNewsItem = EDStatic<typeof DraupnirNewsItem>;
 export const DraupnirNewsItem = Type.Object({
   news_id: Type.String({
@@ -79,7 +80,6 @@ export type NotifyNewsItem = (item: DraupnirNewsItem) => Promise<Result<void>>;
 export class DraupnirNewsLifecycle {
   public constructor(
     private readonly seenNewsIDs: Set<string>,
-    private readonly localNews: DraupnirNewsBlob,
     private readonly storeNews: StoreSeenNews,
     private readonly fetchRemoteNews: FetchRemoteNews,
     private readonly notifyNewsItem: NotifyNewsItem
@@ -91,12 +91,9 @@ export class DraupnirNewsLifecycle {
     const remoteNews = await this.fetchRemoteNews();
     if (isError(remoteNews)) {
       log.error("Unable to fetch news blob", remoteNews.error);
-      // fall through, we still want to be able to show filesystem news.
+      return;
     }
-    const allNews = DraupnirNewsHelper.mergeSources(
-      this.localNews,
-      isOk(remoteNews) ? remoteNews.ok : { news: [] }
-    );
+    const allNews = remoteNews.ok.news;
     const unseenNews = DraupnirNewsHelper.removeSeenNews(
       allNews,
       this.seenNewsIDs
@@ -116,6 +113,8 @@ export class DraupnirNewsLifecycle {
         notifiedNews.push(item);
       }
     }
+    // store only news that is known to have been seen before and the news
+    // which was just confirmed to be notified.
     const updateResult = await this.storeNews(notifiedNews);
     if (isError(updateResult)) {
       log.error("Unable to update stored news", updateResult.error);
@@ -123,15 +122,6 @@ export class DraupnirNewsLifecycle {
     }
   }
 }
-
-const FSNews = (() => {
-  const content = JSON.parse(
-    readFileSync(path.join(__dirname, "./news.json"), "utf8")
-  ) as unknown;
-  return Value.Decode(DraupnirNewsBlob, content).expect(
-    "File system news should match the schema"
-  );
-})();
 
 async function fetchNews(newsURL: string): Promise<Result<DraupnirNewsBlob>> {
   log.debug("Fetching remote news", newsURL);
@@ -190,8 +180,6 @@ export class DraupnirNewsReader {
   }
 }
 
-// Seen news gets cleaned up by storing the merged file system and remote
-// news items which have been notified.
 export const DraupnirNewsProtectionSettings = Type.Object(
   {
     seenNews: Type.Array(Type.String(), {
@@ -233,7 +221,6 @@ export class DraupnirNews
     this.newsReader = new DraupnirNewsReader(
       new DraupnirNewsLifecycle(
         new Set(this.settings.seenNews),
-        FSNews,
         this.updateNews.bind(this),
         () => fetchNews(this.draupnir.config.draupnirNewsURL),
         (item) =>

--- a/apps/draupnir/test/unit/protections/DraupnirNewsTest.ts
+++ b/apps/draupnir/test/unit/protections/DraupnirNewsTest.ts
@@ -2,113 +2,20 @@
 //
 // SPDX-License-Identifier: AFL-3.0
 
-import { Ok, ResultError } from "@gnuxie/typescript-result";
+import { Ok } from "@gnuxie/typescript-result";
 import {
-  DraupnirNewsBlob,
   DraupnirNewsItem,
   DraupnirNewsLifecycle,
 } from "../../../src/protections/DraupnirNews/DraupnirNews";
 import expect from "expect";
 
 describe("DraupnirNewsTest", function () {
-  it("Filesystem news items get sent if the protection hasn't seen them before", async function () {
-    const fileSystemNews = {
-      news: [
-        {
-          news_id: "1",
-          matrix_event_content: {
-            body: "Announcing release v3.0.0!! wohoo",
-            msgtype: "m.text",
-          },
-        },
-        {
-          news_id: "2",
-          matrix_event_content: {
-            body: "Draupnir needs your support!",
-            msgtype: "m.text",
-          },
-        },
-      ],
-    } satisfies DraupnirNewsBlob;
-    const remoteNews = {
-      news: [
-        {
-          news_id: "3",
-          matrix_event_content: {
-            body: "Announcing draupnir news",
-            msgtype: "m.text",
-          },
-        },
-      ],
-    } satisfies DraupnirNewsBlob;
-    const seenNews = new Set<string>();
-    const notifiedNews: string[] = [];
-    const newsLifecycle = new DraupnirNewsLifecycle(
-      seenNews,
-      fileSystemNews,
-      async (allNews) => {
-        allNews.forEach((item) => seenNews.add(item.news_id));
-        return Ok(undefined);
-      },
-      async () => Ok(remoteNews),
-      async (item) => {
-        notifiedNews.push(item.news_id);
-        return Ok(undefined);
-      }
-    );
-    expect(seenNews.size).toBe(0);
-    expect(notifiedNews.length).toBe(0);
-    await newsLifecycle.checkForNews();
-    expect(seenNews.size).toBe(3);
-    expect(notifiedNews.length).toBe(3);
-    await newsLifecycle.checkForNews();
-    expect(notifiedNews.length).toBe(3);
-  });
-  it("Still works if remote news is inaccessible", async function () {
-    const fileSystemNews = {
-      news: [
-        {
-          news_id: "1",
-          matrix_event_content: {
-            body: "Announcing release v3.0.0!! wohoo",
-            msgtype: "m.text",
-          },
-        },
-      ],
-    } satisfies DraupnirNewsBlob;
-    const seenNews = new Set<string>();
-    const notifiedNews: string[] = [];
-    const newsLifecycle = new DraupnirNewsLifecycle(
-      seenNews,
-      fileSystemNews,
-      async (allNews) => {
-        allNews.forEach((item) => seenNews.add(item.news_id));
-        return Ok(undefined);
-      },
-      async () => ResultError.Result("Can't fetch remote news :("),
-      async (item) => {
-        notifiedNews.push(item.news_id);
-        return Ok(undefined);
-      }
-    );
-    expect(seenNews.size).toBe(0);
-    expect(notifiedNews.length).toBe(0);
-    await newsLifecycle.checkForNews();
-    expect(seenNews.size).toBe(1);
-    expect(notifiedNews.length).toBe(1);
-    await newsLifecycle.checkForNews();
-    expect(notifiedNews.length).toBe(1);
-  });
   it("Test news is only stored when there is unseen news", async function () {
-    const fileSystemNews = {
-      news: [],
-    } satisfies DraupnirNewsBlob;
     const seenNews = new Set<string>();
     const storeOperations: DraupnirNewsItem[][] = [];
     const notifiedNews: string[] = [];
     const newsLifecycle = new DraupnirNewsLifecycle(
       seenNews,
-      fileSystemNews,
       async (allNews) => {
         allNews.forEach((item) => seenNews.add(item.news_id));
         storeOperations.push(allNews);


### PR DESCRIPTION
We thought we were being smart by distributing stale news if we couldn't get the news from the remote, but that can be quite bad because old news may be irrelevant, and confuse users. And it's impossible to tell what constitutes old news if you can't reach the remote, which is the only situation in which file system news gets shown. 

Closes https://github.com/the-draupnir-project/planning/issues/130.
Closes https://github.com/the-draupnir-project/Draupnir/issues/1095.