### PR TITLE
Split ProjectionNode deltas into a downstream delta and a node state delta

### DIFF
--- a/apps/draupnir/src/commands/WatchPreview.tsx
+++ b/apps/draupnir/src/commands/WatchPreview.tsx
@@ -38,14 +38,15 @@ function watchDeltaForMemberBanIntents(
     );
   return memberBanIntentProjectionNode.reduceInput(
     setMembershipPoliciesRevisionDelta
-  );
+  ).downstreamDelta;
 }
 
 function watchDeltaForServerBanIntents(
   watchedPoliciesDelta: PolicyRuleChange[],
   serverBanIntentProjectionNode: ServerBanIntentProjectionNode
 ) {
-  return serverBanIntentProjectionNode.reduceInput(watchedPoliciesDelta);
+  return serverBanIntentProjectionNode.reduceInput(watchedPoliciesDelta)
+    .downstreamDelta;
 }
 
 export type WatchPolicyRoomPreview = {

--- a/packages/matrix-protection-suite/src/Projection/Projection.ts
+++ b/packages/matrix-protection-suite/src/Projection/Projection.ts
@@ -70,9 +70,14 @@ export class ProjectionOutputHelper<
     const delta = previousNode.reduceInput(input);
     this.currentNode = previousNode.reduceDelta(delta) as TProjectionNode;
     for (const output of this.outputs) {
-      output.applyInput(delta);
+      output.applyInput(delta.downstreamDelta);
     }
-    this.emitter.emit("projection", this.currentNode, delta, previousNode);
+    this.emitter.emit(
+      "projection",
+      this.currentNode,
+      delta.downstreamDelta,
+      previousNode
+    );
   }
 
   addOutput(projection: Projection): this {

--- a/packages/matrix-protection-suite/src/Projection/ProjectionNode.ts
+++ b/packages/matrix-protection-suite/src/Projection/ProjectionNode.ts
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 Gnuxie <Gnuxie@protonmail.com>
+// SPDX-FileCopyrightText: 2025 - 2026 Gnuxie <Gnuxie@protonmail.com>
 //
 // SPDX-License-Identifier: Apache-2.0
 //
@@ -25,25 +25,75 @@ export type ExtractInputProjectionNodes<
   TProjectionNode extends ProjectionNode,
 > = TProjectionNode extends ProjectionNode<infer TInputs> ? TInputs : never;
 
+export type ProjectionNodeDelta<
+  TDownstreamDeltaShape = unknown,
+  TNodeStateDeltaShape = unknown,
+> = {
+  /**
+   * The externally visible delta produced by this node. This is the only
+   * delta that should be propagated to downstream projection inputs and
+   * projection listeners.
+   */
+  readonly downstreamDelta: TDownstreamDeltaShape;
+  /**
+   * The authoritative state transition for this node. This delta must contain
+   * all information needed by `reduceDelta` to update the node's internal
+   * state, even when the externally visible downstream delta is empty.
+   */
+  readonly nodeStateDelta: TNodeStateDeltaShape;
+};
+
 export type ProjectionNode<
   TInputs extends ProjectionNode[] | unknown[] = unknown[],
-  TDeltaShape = unknown,
+  TDownstreamDeltaShape = unknown,
+  TNodeStateDeltaShape = unknown,
   TAccessMixin = Record<never, never>,
 > = {
   readonly ulid: ULID;
   // Whether the projection has no state at all.
   isEmpty(): boolean;
-  reduceInput(input: ExtractInputDeltaShapes<TInputs>): TDeltaShape;
+  /**
+   * Reduces an input delta into a full projection-node delta.
+   *
+   * The downstream delta is the published effect for downstream projections.
+   * The node-state delta is the complete internal state transition for this
+   * node. These must be derived from the same input and previous node state so
+   * that persisted nodes can be rebuilt by replaying or recomputing node-state
+   * deltas while still producing corrective downstream deltas.
+   */
+  reduceInput(
+    input: ExtractInputDeltaShapes<TInputs>
+  ): ProjectionNodeDelta<TDownstreamDeltaShape, TNodeStateDeltaShape>;
+  /**
+   * Applies a full projection-node delta to produce the next node.
+   *
+   * Implementations must update internal state from `nodeStateDelta`, not from
+   * `downstreamDelta`. The downstream delta can omit internal transitions that
+   * do not cross a downstream-visible boundary, so using it as the source of
+   * truth can make the node inconsistent with its persisted/rebuilt state.
+   */
   reduceDelta(
-    input: TDeltaShape
-  ): ProjectionNode<TInputs, TDeltaShape, TAccessMixin>;
+    projectionNodeDelta: ProjectionNodeDelta<
+      TDownstreamDeltaShape,
+      TNodeStateDeltaShape
+    >
+  ): ProjectionNode<
+    TInputs,
+    TDownstreamDeltaShape,
+    TNodeStateDeltaShape,
+    TAccessMixin
+  >;
   /**
    * Produces the initial delta, can only be used when the revision is empty.
    * Otherwise you must use reduceRebuild.
    */
-  reduceInitialInputs(input: TInputs): TDeltaShape;
+  reduceInitialInputs(
+    input: TInputs
+  ): ProjectionNodeDelta<TDownstreamDeltaShape, TNodeStateDeltaShape>;
   // only needed for persistent storage
-  reduceRebuild?(inputs: TInputs): TDeltaShape;
+  reduceRebuild?(
+    inputs: TInputs
+  ): ProjectionNodeDelta<TDownstreamDeltaShape, TNodeStateDeltaShape>;
 } & TAccessMixin;
 
 export type AnyProjectionNode = ProjectionNode<never>;

--- a/packages/matrix-protection-suite/src/Protection/StandardProtections/MemberBanSynchronisation/MemberBanIntentProjectionNode.ts
+++ b/packages/matrix-protection-suite/src/Protection/StandardProtections/MemberBanSynchronisation/MemberBanIntentProjectionNode.ts
@@ -39,14 +39,17 @@ export type MemberBanInputProjectionNode = ProjectionNode<
 > &
   MembershipPolicyRevision;
 
+export interface MemberBanIntentProjectionDelta {
+  ban: StringUserID[];
+  recall: StringUserID[];
+}
+
 // use add/remove for steady state intents
 // When the intent becomes effectual, matches will be removed
 // upstream and so this model will remain consistent
-export interface MemberBanIntentProjectionDelta {
+export interface MemberBanIntentProjectionStateDelta {
   add: MemberPolicyMatch[];
   remove: MemberPolicyMatch[];
-  ban: StringUserID[];
-  recall: StringUserID[];
 }
 
 function isPolicyRelevant(policy: LiteralPolicyRule | GlobPolicyRule): boolean {
@@ -59,7 +62,7 @@ function isPolicyRelevant(policy: LiteralPolicyRule | GlobPolicyRule): boolean {
 export type MemberBanIntentProjectionNode = ProjectionNode<
   [MemberBanInputProjectionNode],
   MemberBanIntentProjectionDelta,
-  undefined,
+  MemberBanIntentProjectionStateDelta,
   {
     allMembersWithRules(): MemberPolicyMatches[];
     allRulesMatchingMember(
@@ -71,8 +74,8 @@ export type MemberBanIntentProjectionNode = ProjectionNode<
 export const MemberBanIntentProjectionNodeHelper = Object.freeze({
   reduceMembershipPolicyDelta(
     input: MembershipPolicyRevisionDelta
-  ): Pick<MemberBanIntentProjectionDelta, "add" | "remove"> {
-    const output: Pick<MemberBanIntentProjectionDelta, "add" | "remove"> = {
+  ): MemberBanIntentProjectionStateDelta {
+    const output: MemberBanIntentProjectionStateDelta = {
       add: [],
       remove: [],
     };
@@ -89,7 +92,7 @@ export const MemberBanIntentProjectionNodeHelper = Object.freeze({
     return output;
   },
   reduceIntentDelta(
-    input: Pick<MemberBanIntentProjectionDelta, "add" | "remove">,
+    input: MemberBanIntentProjectionStateDelta,
     policies: PersistentMap<
       StringUserID,
       List<LiteralPolicyRule | GlobPolicyRule>
@@ -102,7 +105,6 @@ export const MemberBanIntentProjectionNodeHelper = Object.freeze({
       (rule) => rule.entity as StringUserID
     );
     return {
-      ...input,
       ban: intents.intend,
       recall: intents.recall,
     };
@@ -138,23 +140,28 @@ export class StandardMemberBanIntentProjectionNode implements MemberBanIntentPro
 
   reduceInput(
     input: ExtractInputDeltaShapes<[MemberBanInputProjectionNode]>
-  ): ProjectionNodeDelta<MemberBanIntentProjectionDelta, undefined> {
+  ): ProjectionNodeDelta<
+    MemberBanIntentProjectionDelta,
+    MemberBanIntentProjectionStateDelta
+  > {
+    const nodeStateDelta =
+      MemberBanIntentProjectionNodeHelper.reduceMembershipPolicyDelta(input);
     return {
       downstreamDelta: MemberBanIntentProjectionNodeHelper.reduceIntentDelta(
-        MemberBanIntentProjectionNodeHelper.reduceMembershipPolicyDelta(input),
+        nodeStateDelta,
         this.intents
       ),
-      nodeStateDelta: undefined,
+      nodeStateDelta,
     };
   }
 
   reduceDelta(
     projectionNodeDelta: ProjectionNodeDelta<
       MemberBanIntentProjectionDelta,
-      undefined
+      MemberBanIntentProjectionStateDelta
     >
   ): MemberBanIntentProjectionNode {
-    const input = projectionNodeDelta.downstreamDelta;
+    const input = projectionNodeDelta.nodeStateDelta;
     let nextIntents = this.intents;
     nextIntents = ListMultiMap.addValues(
       nextIntents,
@@ -174,7 +181,10 @@ export class StandardMemberBanIntentProjectionNode implements MemberBanIntentPro
 
   reduceInitialInputs([membershipPolicyRevision]: [
     MemberBanInputProjectionNode,
-  ]): ProjectionNodeDelta<MemberBanIntentProjectionDelta, undefined> {
+  ]): ProjectionNodeDelta<
+    MemberBanIntentProjectionDelta,
+    MemberBanIntentProjectionStateDelta
+  > {
     if (!this.isEmpty()) {
       throw new TypeError(
         "This can only be called on an empty projection node"
@@ -183,17 +193,21 @@ export class StandardMemberBanIntentProjectionNode implements MemberBanIntentPro
     const matches = membershipPolicyRevision
       .allMembersWithRules()
       .map((member) =>
-        member.policies.map((policy) => ({ userID: member.userID, policy }))
+        member.policies
+          .filter(isPolicyRelevant)
+          .map((policy) => ({ userID: member.userID, policy }))
       )
       .flat();
+    const nodeStateDelta = {
+      add: matches,
+      remove: [],
+    };
     return {
       downstreamDelta: {
-        add: matches,
-        ban: matches.map((match) => match.userID),
-        remove: [],
+        ban: [...new Set(matches.map((match) => match.userID))],
         recall: [],
       },
-      nodeStateDelta: undefined,
+      nodeStateDelta,
     };
   }
 

--- a/packages/matrix-protection-suite/src/Protection/StandardProtections/MemberBanSynchronisation/MemberBanIntentProjectionNode.ts
+++ b/packages/matrix-protection-suite/src/Protection/StandardProtections/MemberBanSynchronisation/MemberBanIntentProjectionNode.ts
@@ -11,6 +11,7 @@ import { ULID, ULIDFactory } from "ulidx";
 import {
   ExtractInputDeltaShapes,
   ProjectionNode,
+  ProjectionNodeDelta,
 } from "../../../Projection/ProjectionNode";
 import {
   MemberPolicyMatch,
@@ -33,7 +34,8 @@ import { ListMultiMap } from "../../../Projection/ListMultiMap";
  */
 export type MemberBanInputProjectionNode = ProjectionNode<
   never[],
-  MembershipPolicyRevisionDelta
+  MembershipPolicyRevisionDelta,
+  undefined
 > &
   MembershipPolicyRevision;
 
@@ -57,6 +59,7 @@ function isPolicyRelevant(policy: LiteralPolicyRule | GlobPolicyRule): boolean {
 export type MemberBanIntentProjectionNode = ProjectionNode<
   [MemberBanInputProjectionNode],
   MemberBanIntentProjectionDelta,
+  undefined,
   {
     allMembersWithRules(): MemberPolicyMatches[];
     allRulesMatchingMember(
@@ -135,16 +138,23 @@ export class StandardMemberBanIntentProjectionNode implements MemberBanIntentPro
 
   reduceInput(
     input: ExtractInputDeltaShapes<[MemberBanInputProjectionNode]>
-  ): MemberBanIntentProjectionDelta {
-    return MemberBanIntentProjectionNodeHelper.reduceIntentDelta(
-      MemberBanIntentProjectionNodeHelper.reduceMembershipPolicyDelta(input),
-      this.intents
-    );
+  ): ProjectionNodeDelta<MemberBanIntentProjectionDelta, undefined> {
+    return {
+      downstreamDelta: MemberBanIntentProjectionNodeHelper.reduceIntentDelta(
+        MemberBanIntentProjectionNodeHelper.reduceMembershipPolicyDelta(input),
+        this.intents
+      ),
+      nodeStateDelta: undefined,
+    };
   }
 
   reduceDelta(
-    input: MemberBanIntentProjectionDelta
-  ): StandardMemberBanIntentProjectionNode {
+    projectionNodeDelta: ProjectionNodeDelta<
+      MemberBanIntentProjectionDelta,
+      undefined
+    >
+  ): MemberBanIntentProjectionNode {
+    const input = projectionNodeDelta.downstreamDelta;
     let nextIntents = this.intents;
     nextIntents = ListMultiMap.addValues(
       nextIntents,
@@ -164,7 +174,7 @@ export class StandardMemberBanIntentProjectionNode implements MemberBanIntentPro
 
   reduceInitialInputs([membershipPolicyRevision]: [
     MemberBanInputProjectionNode,
-  ]): MemberBanIntentProjectionDelta {
+  ]): ProjectionNodeDelta<MemberBanIntentProjectionDelta, undefined> {
     if (!this.isEmpty()) {
       throw new TypeError(
         "This can only be called on an empty projection node"
@@ -177,10 +187,13 @@ export class StandardMemberBanIntentProjectionNode implements MemberBanIntentPro
       )
       .flat();
     return {
-      add: matches,
-      ban: matches.map((match) => match.userID),
-      remove: [],
-      recall: [],
+      downstreamDelta: {
+        add: matches,
+        ban: matches.map((match) => match.userID),
+        remove: [],
+        recall: [],
+      },
+      nodeStateDelta: undefined,
     };
   }
 

--- a/packages/matrix-protection-suite/src/Protection/StandardProtections/ServerBanSynchronisation/PolicyListBridgeProjection.ts
+++ b/packages/matrix-protection-suite/src/Protection/StandardProtections/ServerBanSynchronisation/PolicyListBridgeProjection.ts
@@ -14,5 +14,6 @@ import { ProjectionNode } from "../../../Projection/ProjectionNode";
 export type PolicyListBridgeProjectionNode = ProjectionNode<
   [],
   PolicyRuleChange[],
+  undefined,
   PolicyListRevision
 >;

--- a/packages/matrix-protection-suite/src/Protection/StandardProtections/ServerBanSynchronisation/ServerBanIntentProjectionNode.ts
+++ b/packages/matrix-protection-suite/src/Protection/StandardProtections/ServerBanSynchronisation/ServerBanIntentProjectionNode.ts
@@ -31,6 +31,9 @@ import { ListMultiMap } from "../../../Projection/ListMultiMap";
 export type ServerBanIntentProjectionDelta = {
   deny: StringServerName[];
   recall: StringServerName[];
+};
+
+export type ServerBanIntentProjectionStateDelta = {
   add: (LiteralPolicyRule | GlobPolicyRule)[];
   remove: (LiteralPolicyRule | GlobPolicyRule)[];
 };
@@ -41,7 +44,7 @@ export type ServerBanIntentProjectionDelta = {
 export type ServerBanIntentProjectionNode = ProjectionNode<
   [PolicyListBridgeProjectionNode],
   ServerBanIntentProjectionDelta,
-  undefined,
+  ServerBanIntentProjectionStateDelta,
   {
     deny: StringServerName[];
   }
@@ -50,11 +53,11 @@ export type ServerBanIntentProjectionNode = ProjectionNode<
 export const ServerBanIntentProjectionHelper = Object.freeze({
   reducePolicyDelta(
     input: PolicyRuleChange[]
-  ): Pick<ServerBanIntentProjectionDelta, "add" | "remove"> {
-    const output: Pick<ServerBanIntentProjectionDelta, "add" | "remove"> = {
+  ): ServerBanIntentProjectionStateDelta {
+    const output: ServerBanIntentProjectionStateDelta = {
       add: [],
       remove: [],
-    } satisfies Pick<ServerBanIntentProjectionDelta, "add" | "remove">;
+    };
     for (const change of input) {
       if (change.rule.kind !== PolicyRuleType.Server) {
         continue;
@@ -85,7 +88,7 @@ export const ServerBanIntentProjectionHelper = Object.freeze({
   },
 
   reduceIntentDelta(
-    input: Pick<ServerBanIntentProjectionDelta, "add" | "remove">,
+    input: ServerBanIntentProjectionStateDelta,
     policies: PersistentMap<
       StringServerName,
       List<GlobPolicyRule | LiteralPolicyRule>
@@ -98,7 +101,6 @@ export const ServerBanIntentProjectionHelper = Object.freeze({
       (rule) => rule.entity as StringServerName
     );
     return {
-      ...input,
       deny: intents.intend,
       recall: intents.recall,
     };
@@ -128,19 +130,27 @@ export class StandardServerBanIntentProjectionNode implements ServerBanIntentPro
 
   reduceInput(
     input: PolicyRuleChange[]
-  ): ProjectionNodeDelta<ServerBanIntentProjectionDelta, undefined> {
+  ): ProjectionNodeDelta<
+    ServerBanIntentProjectionDelta,
+    ServerBanIntentProjectionStateDelta
+  > {
+    const nodeStateDelta =
+      ServerBanIntentProjectionHelper.reducePolicyDelta(input);
     return {
       downstreamDelta: ServerBanIntentProjectionHelper.reduceIntentDelta(
-        ServerBanIntentProjectionHelper.reducePolicyDelta(input),
+        nodeStateDelta,
         this.policies
       ),
-      nodeStateDelta: undefined,
+      nodeStateDelta,
     };
   }
 
   reduceInitialInputs([policyListRevision]: [
     PolicyListBridgeProjectionNode,
-  ]): ProjectionNodeDelta<ServerBanIntentProjectionDelta, undefined> {
+  ]): ProjectionNodeDelta<
+    ServerBanIntentProjectionDelta,
+    ServerBanIntentProjectionStateDelta
+  > {
     if (!this.isEmpty()) {
       throw new TypeError("Cannot reduce initial inputs when inialised");
     }
@@ -156,14 +166,16 @@ export class StandardServerBanIntentProjectionNode implements ServerBanIntentPro
     ].filter((rule) => rule.matchType !== PolicyRuleMatchType.HashedLiteral);
     const names = new Set(serverPolicies.map((policy) => policy.entity));
     const downstreamDelta = {
-      add: serverPolicies,
       deny: [...names] as StringServerName[],
-      remove: [],
       recall: [],
+    };
+    const nodeStateDelta = {
+      add: serverPolicies,
+      remove: [],
     };
     return {
       downstreamDelta,
-      nodeStateDelta: undefined,
+      nodeStateDelta,
     };
   }
 
@@ -172,10 +184,10 @@ export class StandardServerBanIntentProjectionNode implements ServerBanIntentPro
   }
 
   reduceDelta({
-    downstreamDelta: input,
+    nodeStateDelta: input,
   }: ProjectionNodeDelta<
     ServerBanIntentProjectionDelta,
-    undefined
+    ServerBanIntentProjectionStateDelta
   >): ServerBanIntentProjectionNode {
     let nextPolicies = this.policies;
     nextPolicies = ListMultiMap.addValues(

--- a/packages/matrix-protection-suite/src/Protection/StandardProtections/ServerBanSynchronisation/ServerBanIntentProjectionNode.ts
+++ b/packages/matrix-protection-suite/src/Protection/StandardProtections/ServerBanSynchronisation/ServerBanIntentProjectionNode.ts
@@ -8,7 +8,10 @@
 // </text>
 
 import { StringServerName } from "@the-draupnir-project/matrix-basic-types";
-import { ProjectionNode } from "../../../Projection/ProjectionNode";
+import {
+  ProjectionNode,
+  ProjectionNodeDelta,
+} from "../../../Projection/ProjectionNode";
 import { PolicyListBridgeProjectionNode } from "./PolicyListBridgeProjection";
 import {
   PolicyRuleChange,
@@ -38,6 +41,7 @@ export type ServerBanIntentProjectionDelta = {
 export type ServerBanIntentProjectionNode = ProjectionNode<
   [PolicyListBridgeProjectionNode],
   ServerBanIntentProjectionDelta,
+  undefined,
   {
     deny: StringServerName[];
   }
@@ -122,15 +126,21 @@ export class StandardServerBanIntentProjectionNode implements ServerBanIntentPro
     );
   }
 
-  reduceInput(input: PolicyRuleChange[]): ServerBanIntentProjectionDelta {
-    return ServerBanIntentProjectionHelper.reduceIntentDelta(
-      ServerBanIntentProjectionHelper.reducePolicyDelta(input),
-      this.policies
-    );
+  reduceInput(
+    input: PolicyRuleChange[]
+  ): ProjectionNodeDelta<ServerBanIntentProjectionDelta, undefined> {
+    return {
+      downstreamDelta: ServerBanIntentProjectionHelper.reduceIntentDelta(
+        ServerBanIntentProjectionHelper.reducePolicyDelta(input),
+        this.policies
+      ),
+      nodeStateDelta: undefined,
+    };
   }
+
   reduceInitialInputs([policyListRevision]: [
     PolicyListBridgeProjectionNode,
-  ]): ServerBanIntentProjectionDelta {
+  ]): ProjectionNodeDelta<ServerBanIntentProjectionDelta, undefined> {
     if (!this.isEmpty()) {
       throw new TypeError("Cannot reduce initial inputs when inialised");
     }
@@ -145,11 +155,15 @@ export class StandardServerBanIntentProjectionNode implements ServerBanIntentPro
       ),
     ].filter((rule) => rule.matchType !== PolicyRuleMatchType.HashedLiteral);
     const names = new Set(serverPolicies.map((policy) => policy.entity));
-    return {
+    const downstreamDelta = {
       add: serverPolicies,
       deny: [...names] as StringServerName[],
       remove: [],
       recall: [],
+    };
+    return {
+      downstreamDelta,
+      nodeStateDelta: undefined,
     };
   }
 
@@ -157,9 +171,12 @@ export class StandardServerBanIntentProjectionNode implements ServerBanIntentPro
     return this.policies.size === 0;
   }
 
-  reduceDelta(
-    input: ServerBanIntentProjectionDelta
-  ): ServerBanIntentProjectionNode {
+  reduceDelta({
+    downstreamDelta: input,
+  }: ProjectionNodeDelta<
+    ServerBanIntentProjectionDelta,
+    undefined
+  >): ServerBanIntentProjectionNode {
     let nextPolicies = this.policies;
     nextPolicies = ListMultiMap.addValues(
       nextPolicies,


### PR DESCRIPTION
Previously the projection node delta conflated two responsibilities, one was to update the internal state of the projection node and the other was to produce a delta that downstream could consume.

We didn't really notice this until we tried to make a projection that had unrelated nonsense in the downstream delta. So this PR makes the different parts explicit.

We also [tried to look at a  "single step" reducer model](https://github.com/the-draupnir-project/planning/issues/120#issuecomment-4245959599) that only produced a downstream delta. It looks like the single-step model is quite similar to what is actually implemented and bugs in diff code have to be figured out the same way.

It's probably worth exploring the single-step model now that we have discovered what two-step actually entails. 

Closes https://github.com/the-draupnir-project/planning/issues/123 