### PR TITLE
Make ProjectionNode reduction single-step

### DIFF
--- a/.changeset/smart-eyes-cover.md
+++ b/.changeset/smart-eyes-cover.md
@@ -1,0 +1,11 @@
+---
+"@the-draupnir-project/matrix-protection-suite": minor
+---
+
+Projections now produce the next node in a single step, which simplifies their
+implementation.
+
+Previously we thought that the two-step system had stronger guarantees for
+correctness when persisting projection nodes, but we found in implementation
+that the two approaches were almost identical, with two-step being needlessly
+complicated https://github.com/the-draupnir-project/planning/issues/120

--- a/apps/draupnir/src/commands/WatchPreview.tsx
+++ b/apps/draupnir/src/commands/WatchPreview.tsx
@@ -38,14 +38,15 @@ function watchDeltaForMemberBanIntents(
     );
   return memberBanIntentProjectionNode.reduceInput(
     setMembershipPoliciesRevisionDelta
-  );
+  ).downstreamDelta;
 }
 
 function watchDeltaForServerBanIntents(
   watchedPoliciesDelta: PolicyRuleChange[],
   serverBanIntentProjectionNode: ServerBanIntentProjectionNode
 ) {
-  return serverBanIntentProjectionNode.reduceInput(watchedPoliciesDelta);
+  return serverBanIntentProjectionNode.reduceInput(watchedPoliciesDelta)
+    .downstreamDelta;
 }
 
 export type WatchPolicyRoomPreview = {

--- a/apps/draupnir/src/commands/WatchPreview.tsx
+++ b/apps/draupnir/src/commands/WatchPreview.tsx
@@ -36,17 +36,19 @@ function watchDeltaForMemberBanIntents(
       watchedPoliciesDelta,
       setMembershipRevision
     );
-  return memberBanIntentProjectionNode.reduceInput(
+  const nextNode = memberBanIntentProjectionNode.reduceInput(
     setMembershipPoliciesRevisionDelta
-  ).downstreamDelta;
+  );
+  return memberBanIntentProjectionNode.diff(nextNode);
 }
 
 function watchDeltaForServerBanIntents(
   watchedPoliciesDelta: PolicyRuleChange[],
   serverBanIntentProjectionNode: ServerBanIntentProjectionNode
 ) {
-  return serverBanIntentProjectionNode.reduceInput(watchedPoliciesDelta)
-    .downstreamDelta;
+  const nextNode =
+    serverBanIntentProjectionNode.reduceInput(watchedPoliciesDelta);
+  return serverBanIntentProjectionNode.diff(nextNode);
 }
 
 export type WatchPolicyRoomPreview = {

--- a/packages/matrix-protection-suite/src/Projection/Projection.ts
+++ b/packages/matrix-protection-suite/src/Projection/Projection.ts
@@ -67,15 +67,15 @@ export class ProjectionOutputHelper<
     input: ExtractInputDeltaShapes<ExtractInputProjectionNodes<TProjectionNode>>
   ): void {
     const previousNode = this.currentNode;
-    const delta = previousNode.reduceInput(input);
-    this.currentNode = previousNode.reduceDelta(delta) as TProjectionNode;
+    const reduction = previousNode.reduceInput(input);
+    this.currentNode = reduction.nextNode as TProjectionNode;
     for (const output of this.outputs) {
-      output.applyInput(delta.downstreamDelta);
+      output.applyInput(reduction.downstreamDelta);
     }
     this.emitter.emit(
       "projection",
       this.currentNode,
-      delta.downstreamDelta,
+      reduction.downstreamDelta,
       previousNode
     );
   }

--- a/packages/matrix-protection-suite/src/Projection/Projection.ts
+++ b/packages/matrix-protection-suite/src/Projection/Projection.ts
@@ -70,9 +70,14 @@ export class ProjectionOutputHelper<
     const delta = previousNode.reduceInput(input);
     this.currentNode = previousNode.reduceDelta(delta) as TProjectionNode;
     for (const output of this.outputs) {
-      output.applyInput(delta);
+      output.applyInput(delta.downstreamDelta);
     }
-    this.emitter.emit("projection", this.currentNode, delta, previousNode);
+    this.emitter.emit(
+      "projection",
+      this.currentNode,
+      delta.downstreamDelta,
+      previousNode
+    );
   }
 
   addOutput(projection: Projection): this {

--- a/packages/matrix-protection-suite/src/Projection/Projection.ts
+++ b/packages/matrix-protection-suite/src/Projection/Projection.ts
@@ -67,15 +67,15 @@ export class ProjectionOutputHelper<
     input: ExtractInputDeltaShapes<ExtractInputProjectionNodes<TProjectionNode>>
   ): void {
     const previousNode = this.currentNode;
-    const reduction = previousNode.reduceInput(input);
-    this.currentNode = reduction.nextNode as TProjectionNode;
+    this.currentNode = previousNode.reduceInput(input) as TProjectionNode;
+    const downstreamDelta = previousNode.diff(this.currentNode);
     for (const output of this.outputs) {
-      output.applyInput(reduction.downstreamDelta);
+      output.applyInput(downstreamDelta);
     }
     this.emitter.emit(
       "projection",
       this.currentNode,
-      reduction.downstreamDelta,
+      downstreamDelta,
       previousNode
     );
   }

--- a/packages/matrix-protection-suite/src/Projection/ProjectionNode.ts
+++ b/packages/matrix-protection-suite/src/Projection/ProjectionNode.ts
@@ -25,75 +25,70 @@ export type ExtractInputProjectionNodes<
   TProjectionNode extends ProjectionNode,
 > = TProjectionNode extends ProjectionNode<infer TInputs> ? TInputs : never;
 
-export type ProjectionNodeDelta<
-  TDownstreamDeltaShape = unknown,
-  TNodeStateDeltaShape = unknown,
+export type ProjectionReduction<
+  TNextProjectionNode extends ProjectionNode = ProjectionNode,
+  TDownstreamDeltaShape = ExtractDeltaShape<TNextProjectionNode>,
 > = {
-  /**
-   * The externally visible delta produced by this node. This is the only
-   * delta that should be propagated to downstream projection inputs and
-   * projection listeners.
-   */
+  readonly nextNode: TNextProjectionNode;
   readonly downstreamDelta: TDownstreamDeltaShape;
-  /**
-   * The authoritative state transition for this node. This delta must contain
-   * all information needed by `reduceDelta` to update the node's internal
-   * state, even when the externally visible downstream delta is empty.
-   */
-  readonly nodeStateDelta: TNodeStateDeltaShape;
 };
 
 export type ProjectionNode<
   TInputs extends ProjectionNode[] | unknown[] = unknown[],
   TDownstreamDeltaShape = unknown,
-  TNodeStateDeltaShape = unknown,
   TAccessMixin = Record<never, never>,
 > = {
   readonly ulid: ULID;
   // Whether the projection has no state at all.
   isEmpty(): boolean;
   /**
-   * Reduces an input delta into a full projection-node delta.
+   * Produces the externally visible delta with the difference between two
+   * nodes. This delta is for downstream projections to consume, not the
+   * projection itself. To replay and reproduce the projection node
+   * from deltas you have to use the input deltas.
+   */
+  diff(
+    nextNode: ProjectionNode<TInputs, TDownstreamDeltaShape, TAccessMixin>
+  ): TDownstreamDeltaShape;
+  /**
+   * Reduces an input delta into the next projection node and the externally
+   * visible delta that should be propagated to downstream projections.
    *
-   * The downstream delta is the published effect for downstream projections.
-   * The node-state delta is the complete internal state transition for this
-   * node. These must be derived from the same input and previous node state so
-   * that persisted nodes can be rebuilt by replaying or recomputing node-state
-   * deltas while still producing corrective downstream deltas.
+   * The downstream delta should describe the public effect of moving from this
+   * node to `nextNode`.
    */
   reduceInput(
     input: ExtractInputDeltaShapes<TInputs>
-  ): ProjectionNodeDelta<TDownstreamDeltaShape, TNodeStateDeltaShape>;
-  /**
-   * Applies a full projection-node delta to produce the next node.
-   *
-   * Implementations must update internal state from `nodeStateDelta`, not from
-   * `downstreamDelta`. The downstream delta can omit internal transitions that
-   * do not cross a downstream-visible boundary, so using it as the source of
-   * truth can make the node inconsistent with its persisted/rebuilt state.
-   */
-  reduceDelta(
-    projectionNodeDelta: ProjectionNodeDelta<
-      TDownstreamDeltaShape,
-      TNodeStateDeltaShape
-    >
-  ): ProjectionNode<
-    TInputs,
-    TDownstreamDeltaShape,
-    TNodeStateDeltaShape,
-    TAccessMixin
+  ): ProjectionReduction<
+    ProjectionNode<TInputs, TDownstreamDeltaShape, TAccessMixin>,
+    TDownstreamDeltaShape
   >;
   /**
-   * Produces the initial delta, can only be used when the revision is empty.
-   * Otherwise you must use reduceRebuild.
+   * Produces the initial node and downstream delta from the current input
+   * projection nodes. This can only be used when the node is empty. Otherwise
+   * use reduceRebuild.
    */
   reduceInitialInputs(
     input: TInputs
-  ): ProjectionNodeDelta<TDownstreamDeltaShape, TNodeStateDeltaShape>;
-  // only needed for persistent storage
+  ): ProjectionReduction<
+    ProjectionNode<TInputs, TDownstreamDeltaShape, TAccessMixin>,
+    TDownstreamDeltaShape
+  >;
+  /**
+   * Reconciles this node against the current input projection nodes. This is
+   * intended for persistence/rebuild flows and for producing corrective
+   * downstream deltas after reducer bugs are fixed.
+   *
+   * Implementations should compute the corrected node from `inputs`, then
+   * produce the downstream delta by diffing this node against that corrected
+   * node.
+   */
   reduceRebuild?(
     inputs: TInputs
-  ): ProjectionNodeDelta<TDownstreamDeltaShape, TNodeStateDeltaShape>;
+  ): ProjectionReduction<
+    ProjectionNode<TInputs, TDownstreamDeltaShape, TAccessMixin>,
+    TDownstreamDeltaShape
+  >;
 } & TAccessMixin;
 
 export type AnyProjectionNode = ProjectionNode<never>;

--- a/packages/matrix-protection-suite/src/Projection/ProjectionNode.ts
+++ b/packages/matrix-protection-suite/src/Projection/ProjectionNode.ts
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 Gnuxie <Gnuxie@protonmail.com>
+// SPDX-FileCopyrightText: 2025 - 2026 Gnuxie <Gnuxie@protonmail.com>
 //
 // SPDX-License-Identifier: Apache-2.0
 //
@@ -25,25 +25,75 @@ export type ExtractInputProjectionNodes<
   TProjectionNode extends ProjectionNode,
 > = TProjectionNode extends ProjectionNode<infer TInputs> ? TInputs : never;
 
+export type ProjectionNodeDelta<
+  TDownstreamDeltaShape = unknown,
+  TNodeStateDeltaShape = unknown,
+> = {
+  /**
+   * The externally visible delta produced by this node. This is the only
+   * delta that should be propagated to downstream projection inputs and
+   * projection listeners.
+   */
+  readonly downstreamDelta: TDownstreamDeltaShape;
+  /**
+   * The authoritative state transition for this node. This delta must contain
+   * all information needed by `reduceDelta` to update the node's internal
+   * state, even when the externally visible downstream delta is empty.
+   */
+  readonly nodeStateDelta: TNodeStateDeltaShape;
+};
+
 export type ProjectionNode<
   TInputs extends ProjectionNode[] | unknown[] = unknown[],
-  TDeltaShape = unknown,
+  TDownstreamDeltaShape = unknown,
+  TNodeStateDeltaShape = unknown,
   TAccessMixin = Record<never, never>,
 > = {
   readonly ulid: ULID;
   // Whether the projection has no state at all.
   isEmpty(): boolean;
-  reduceInput(input: ExtractInputDeltaShapes<TInputs>): TDeltaShape;
+  /**
+   * Reduces an input delta into a full projection-node delta.
+   *
+   * The downstream delta is the published effect for downstream projections.
+   * The node-state delta is the complete internal state transition for this
+   * node. These must be derived from the same input and previous node state so
+   * that persisted nodes can be rebuilt by replaying or recomputing node-state
+   * deltas while still producing corrective downstream deltas.
+   */
+  reduceInput(
+    input: ExtractInputDeltaShapes<TInputs>
+  ): ProjectionNodeDelta<TDownstreamDeltaShape, TNodeStateDeltaShape>;
+  /**
+   * Applies a full projection-node delta to produce the next node.
+   *
+   * Implementations must update internal state from `nodeStateDelta`, not from
+   * `downstreamDelta`. The downstream delta can omit internal transitions that
+   * do not cross a downstream-visible boundary, so using it as the source of
+   * truth can make the node inconsistent with its persisted/rebuilt state.
+   */
   reduceDelta(
-    input: TDeltaShape
-  ): ProjectionNode<TInputs, TDeltaShape, TAccessMixin>;
+    projectionNodeDelta: ProjectionNodeDelta<
+      TDownstreamDeltaShape,
+      TNodeStateDeltaShape
+    >
+  ): ProjectionNode<
+    TInputs,
+    TDownstreamDeltaShape,
+    TNodeStateDeltaShape,
+    TAccessMixin
+  >;
   /**
    * Produces the initial delta, can only be used when the revision is empty.
    * Otherwise you must use reduceRebuild.
    */
-  reduceInitialInputs(input: TInputs): TDeltaShape;
+  reduceInitialInputs(
+    input: TInputs
+  ): ProjectionNodeDelta<TDownstreamDeltaShape, TNodeStateDeltaShape>;
   // only needed for persistent storage
-  reduceRebuild?(inputs: TInputs): TDeltaShape;
+  reduceRebuild?(
+    inputs: TInputs
+  ): ProjectionNodeDelta<TDownstreamDeltaShape, TNodeStateDeltaShape>;
 } & TAccessMixin;
 
 export type AnyProjectionNode = ProjectionNode<never>;

--- a/packages/matrix-protection-suite/src/Projection/ProjectionNode.ts
+++ b/packages/matrix-protection-suite/src/Projection/ProjectionNode.ts
@@ -25,14 +25,6 @@ export type ExtractInputProjectionNodes<
   TProjectionNode extends ProjectionNode,
 > = TProjectionNode extends ProjectionNode<infer TInputs> ? TInputs : never;
 
-export type ProjectionReduction<
-  TNextProjectionNode extends ProjectionNode = ProjectionNode,
-  TDownstreamDeltaShape = ExtractDeltaShape<TNextProjectionNode>,
-> = {
-  readonly nextNode: TNextProjectionNode;
-  readonly downstreamDelta: TDownstreamDeltaShape;
-};
-
 export type ProjectionNode<
   TInputs extends ProjectionNode[] | unknown[] = unknown[],
   TDownstreamDeltaShape = unknown,
@@ -51,44 +43,28 @@ export type ProjectionNode<
     nextNode: ProjectionNode<TInputs, TDownstreamDeltaShape, TAccessMixin>
   ): TDownstreamDeltaShape;
   /**
-   * Reduces an input delta into the next projection node and the externally
-   * visible delta that should be propagated to downstream projections.
-   *
-   * The downstream delta should describe the public effect of moving from this
-   * node to `nextNode`.
+   * Reduces an input delta into the next projection node.
    */
   reduceInput(
     input: ExtractInputDeltaShapes<TInputs>
-  ): ProjectionReduction<
-    ProjectionNode<TInputs, TDownstreamDeltaShape, TAccessMixin>,
-    TDownstreamDeltaShape
-  >;
+  ): ProjectionNode<TInputs, TDownstreamDeltaShape, TAccessMixin>;
   /**
-   * Produces the initial node and downstream delta from the current input
-   * projection nodes. This can only be used when the node is empty. Otherwise
-   * use reduceRebuild.
+   * Produces the initial node from the current input projection nodes. This can
+   * only be used when the node is empty. Otherwise use reduceRebuild.
    */
   reduceInitialInputs(
     input: TInputs
-  ): ProjectionReduction<
-    ProjectionNode<TInputs, TDownstreamDeltaShape, TAccessMixin>,
-    TDownstreamDeltaShape
-  >;
+  ): ProjectionNode<TInputs, TDownstreamDeltaShape, TAccessMixin>;
   /**
    * Reconciles this node against the current input projection nodes. This is
-   * intended for persistence/rebuild flows and for producing corrective
-   * downstream deltas after reducer bugs are fixed.
+   * intended for persistence/rebuild flows after reducer bugs are fixed.
    *
-   * Implementations should compute the corrected node from `inputs`, then
-   * produce the downstream delta by diffing this node against that corrected
-   * node.
+   * The projection or orchestration layer is responsible for publishing the
+   * corrective downstream delta by diffing this node against the corrected node.
    */
   reduceRebuild?(
     inputs: TInputs
-  ): ProjectionReduction<
-    ProjectionNode<TInputs, TDownstreamDeltaShape, TAccessMixin>,
-    TDownstreamDeltaShape
-  >;
+  ): ProjectionNode<TInputs, TDownstreamDeltaShape, TAccessMixin>;
 } & TAccessMixin;
 
 export type AnyProjectionNode = ProjectionNode<never>;

--- a/packages/matrix-protection-suite/src/Protection/StandardProtections/MemberBanSynchronisation/MemberBanIntentProjection.ts
+++ b/packages/matrix-protection-suite/src/Protection/StandardProtections/MemberBanSynchronisation/MemberBanIntentProjection.ts
@@ -34,10 +34,10 @@ export class StandardMemberBanIntentProjection
   ) {
     const node =
       StandardMemberBanIntentProjectionNode.create(monotonicFactory());
-    const reduction = node.reduceInitialInputs([
+    const initialNode = node.reduceInitialInputs([
       membershipPolicyRevisionIssuer.currentRevision as unknown as MemberBanInputProjectionNode,
     ]);
-    super(reduction.nextNode);
+    super(initialNode);
     this.membershipPolicyRevisionIssuer.on(
       "revision",
       this.handleUpstreamRevision

--- a/packages/matrix-protection-suite/src/Protection/StandardProtections/MemberBanSynchronisation/MemberBanIntentProjection.ts
+++ b/packages/matrix-protection-suite/src/Protection/StandardProtections/MemberBanSynchronisation/MemberBanIntentProjection.ts
@@ -34,10 +34,10 @@ export class StandardMemberBanIntentProjection
   ) {
     const node =
       StandardMemberBanIntentProjectionNode.create(monotonicFactory());
-    const delta = node.reduceInitialInputs([
+    const reduction = node.reduceInitialInputs([
       membershipPolicyRevisionIssuer.currentRevision as unknown as MemberBanInputProjectionNode,
     ]);
-    super(node.reduceDelta(delta));
+    super(reduction.nextNode);
     this.membershipPolicyRevisionIssuer.on(
       "revision",
       this.handleUpstreamRevision

--- a/packages/matrix-protection-suite/src/Protection/StandardProtections/MemberBanSynchronisation/MemberBanIntentProjectionNode.ts
+++ b/packages/matrix-protection-suite/src/Protection/StandardProtections/MemberBanSynchronisation/MemberBanIntentProjectionNode.ts
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 Gnuxie <Gnuxie@protonmail.com>
+// SPDX-FileCopyrightText: 2025 - 2026 Gnuxie <Gnuxie@protonmail.com>
 //
 // SPDX-License-Identifier: Apache-2.0
 //
@@ -11,10 +11,9 @@ import { ULID, ULIDFactory } from "ulidx";
 import {
   ExtractInputDeltaShapes,
   ProjectionNode,
-  ProjectionNodeDelta,
+  ProjectionReduction,
 } from "../../../Projection/ProjectionNode";
 import {
-  MemberPolicyMatch,
   MemberPolicyMatches,
   MembershipPolicyRevision,
   MembershipPolicyRevisionDelta,
@@ -34,8 +33,7 @@ import { ListMultiMap } from "../../../Projection/ListMultiMap";
  */
 export type MemberBanInputProjectionNode = ProjectionNode<
   never[],
-  MembershipPolicyRevisionDelta,
-  undefined
+  MembershipPolicyRevisionDelta
 > &
   MembershipPolicyRevision;
 
@@ -44,13 +42,10 @@ export interface MemberBanIntentProjectionDelta {
   recall: StringUserID[];
 }
 
-// use add/remove for steady state intents
-// When the intent becomes effectual, matches will be removed
-// upstream and so this model will remain consistent
-export interface MemberBanIntentProjectionStateDelta {
-  add: MemberPolicyMatch[];
-  remove: MemberPolicyMatch[];
-}
+type MemberBanIntentMap = PersistentMap<
+  StringUserID,
+  List<LiteralPolicyRule | GlobPolicyRule>
+>;
 
 function isPolicyRelevant(policy: LiteralPolicyRule | GlobPolicyRule): boolean {
   return (
@@ -62,54 +57,14 @@ function isPolicyRelevant(policy: LiteralPolicyRule | GlobPolicyRule): boolean {
 export type MemberBanIntentProjectionNode = ProjectionNode<
   [MemberBanInputProjectionNode],
   MemberBanIntentProjectionDelta,
-  MemberBanIntentProjectionStateDelta,
   {
     allMembersWithRules(): MemberPolicyMatches[];
+    isMemberBanned(member: StringUserID): boolean;
     allRulesMatchingMember(
       member: StringUserID
     ): (LiteralPolicyRule | GlobPolicyRule)[];
   }
 >;
-
-export const MemberBanIntentProjectionNodeHelper = Object.freeze({
-  reduceMembershipPolicyDelta(
-    input: MembershipPolicyRevisionDelta
-  ): MemberBanIntentProjectionStateDelta {
-    const output: MemberBanIntentProjectionStateDelta = {
-      add: [],
-      remove: [],
-    };
-    for (const added of input.addedMemberMatches) {
-      if (isPolicyRelevant(added.policy)) {
-        output.add.push(added);
-      }
-    }
-    for (const removed of input.removedMemberMatches) {
-      if (isPolicyRelevant(removed.policy)) {
-        output.remove.push(removed);
-      }
-    }
-    return output;
-  },
-  reduceIntentDelta(
-    input: MemberBanIntentProjectionStateDelta,
-    policies: PersistentMap<
-      StringUserID,
-      List<LiteralPolicyRule | GlobPolicyRule>
-    >
-  ): MemberBanIntentProjectionDelta {
-    const intents = ListMultiMap.deriveIntents(
-      policies,
-      input.add.map((match) => match.policy),
-      input.remove.map((match) => match.policy),
-      (rule) => rule.entity as StringUserID
-    );
-    return {
-      ban: intents.intend,
-      recall: intents.recall,
-    };
-  },
-});
 
 // Upstream inputs are not yet converted to projections, so have to be never[]
 // for now.
@@ -117,10 +72,7 @@ export class StandardMemberBanIntentProjectionNode implements MemberBanIntentPro
   public readonly ulid: ULID;
   constructor(
     private readonly ulidFactory: ULIDFactory,
-    private readonly intents: PersistentMap<
-      StringUserID,
-      List<LiteralPolicyRule | GlobPolicyRule>
-    >
+    private readonly intents: MemberBanIntentMap
   ) {
     this.ulid = ulidFactory();
   }
@@ -138,52 +90,60 @@ export class StandardMemberBanIntentProjectionNode implements MemberBanIntentPro
     return this.intents.isEmpty();
   }
 
-  reduceInput(
-    input: ExtractInputDeltaShapes<[MemberBanInputProjectionNode]>
-  ): ProjectionNodeDelta<
-    MemberBanIntentProjectionDelta,
-    MemberBanIntentProjectionStateDelta
-  > {
-    const nodeStateDelta =
-      MemberBanIntentProjectionNodeHelper.reduceMembershipPolicyDelta(input);
-    return {
-      downstreamDelta: MemberBanIntentProjectionNodeHelper.reduceIntentDelta(
-        nodeStateDelta,
-        this.intents
-      ),
-      nodeStateDelta,
-    };
+  public diff(
+    nextNode: MemberBanIntentProjectionNode
+  ): MemberBanIntentProjectionDelta {
+    const ban: StringUserID[] = [];
+    const recall: StringUserID[] = [];
+    for (const member of nextNode.allMembersWithRules()) {
+      if (!this.isMemberBanned(member.userID)) {
+        ban.push(member.userID);
+      }
+    }
+    for (const userID of this.intents.keys()) {
+      if (!nextNode.isMemberBanned(userID)) {
+        recall.push(userID);
+      }
+    }
+    return { ban, recall };
   }
 
-  reduceDelta(
-    projectionNodeDelta: ProjectionNodeDelta<
-      MemberBanIntentProjectionDelta,
-      MemberBanIntentProjectionStateDelta
-    >
-  ): MemberBanIntentProjectionNode {
-    const input = projectionNodeDelta.nodeStateDelta;
+  reduceInput(
+    input: ExtractInputDeltaShapes<[MemberBanInputProjectionNode]>
+  ): ProjectionReduction<
+    MemberBanIntentProjectionNode,
+    MemberBanIntentProjectionDelta
+  > {
     let nextIntents = this.intents;
-    nextIntents = ListMultiMap.addValues(
-      nextIntents,
-      input.add.map((match) => match.policy),
-      (rule) => rule.entity as StringUserID
-    );
-    nextIntents = ListMultiMap.removeValues(
-      nextIntents,
-      input.remove.map((match) => match.policy),
-      (rule) => rule.entity as StringUserID
-    );
-    return new StandardMemberBanIntentProjectionNode(
+    for (const added of input.addedMemberMatches) {
+      if (isPolicyRelevant(added.policy)) {
+        nextIntents = ListMultiMap.add(nextIntents, added.userID, added.policy);
+      }
+    }
+    for (const removed of input.removedMemberMatches) {
+      if (isPolicyRelevant(removed.policy)) {
+        nextIntents = ListMultiMap.remove(
+          nextIntents,
+          removed.userID,
+          removed.policy
+        );
+      }
+    }
+    const nextNode = new StandardMemberBanIntentProjectionNode(
       this.ulidFactory,
       nextIntents
     );
+    return {
+      downstreamDelta: this.diff(nextNode),
+      nextNode,
+    };
   }
 
   reduceInitialInputs([membershipPolicyRevision]: [
     MemberBanInputProjectionNode,
-  ]): ProjectionNodeDelta<
-    MemberBanIntentProjectionDelta,
-    MemberBanIntentProjectionStateDelta
+  ]): ProjectionReduction<
+    MemberBanIntentProjectionNode,
+    MemberBanIntentProjectionDelta
   > {
     if (!this.isEmpty()) {
       throw new TypeError(
@@ -198,16 +158,20 @@ export class StandardMemberBanIntentProjectionNode implements MemberBanIntentPro
           .map((policy) => ({ userID: member.userID, policy }))
       )
       .flat();
-    const nodeStateDelta = {
-      add: matches,
-      remove: [],
-    };
+    let nextIntents = PersistentMap<
+      StringUserID,
+      List<LiteralPolicyRule | GlobPolicyRule>
+    >();
+    for (const match of matches) {
+      nextIntents = ListMultiMap.add(nextIntents, match.userID, match.policy);
+    }
+    const nextNode = new StandardMemberBanIntentProjectionNode(
+      this.ulidFactory,
+      nextIntents
+    );
     return {
-      downstreamDelta: {
-        ban: [...new Set(matches.map((match) => match.userID))],
-        recall: [],
-      },
-      nodeStateDelta,
+      downstreamDelta: this.diff(nextNode),
+      nextNode,
     };
   }
 
@@ -222,6 +186,10 @@ export class StandardMemberBanIntentProjectionNode implements MemberBanIntentPro
       },
       []
     );
+  }
+
+  isMemberBanned(member: StringUserID): boolean {
+    return this.intents.has(member);
   }
 
   allRulesMatchingMember(

--- a/packages/matrix-protection-suite/src/Protection/StandardProtections/MemberBanSynchronisation/MemberBanIntentProjectionNode.ts
+++ b/packages/matrix-protection-suite/src/Protection/StandardProtections/MemberBanSynchronisation/MemberBanIntentProjectionNode.ts
@@ -11,7 +11,6 @@ import { ULID, ULIDFactory } from "ulidx";
 import {
   ExtractInputDeltaShapes,
   ProjectionNode,
-  ProjectionReduction,
 } from "../../../Projection/ProjectionNode";
 import {
   MemberPolicyMatches,
@@ -110,10 +109,7 @@ export class StandardMemberBanIntentProjectionNode implements MemberBanIntentPro
 
   reduceInput(
     input: ExtractInputDeltaShapes<[MemberBanInputProjectionNode]>
-  ): ProjectionReduction<
-    MemberBanIntentProjectionNode,
-    MemberBanIntentProjectionDelta
-  > {
+  ): MemberBanIntentProjectionNode {
     let nextIntents = this.intents;
     for (const added of input.addedMemberMatches) {
       if (isPolicyRelevant(added.policy)) {
@@ -129,22 +125,15 @@ export class StandardMemberBanIntentProjectionNode implements MemberBanIntentPro
         );
       }
     }
-    const nextNode = new StandardMemberBanIntentProjectionNode(
+    return new StandardMemberBanIntentProjectionNode(
       this.ulidFactory,
       nextIntents
     );
-    return {
-      downstreamDelta: this.diff(nextNode),
-      nextNode,
-    };
   }
 
   reduceInitialInputs([membershipPolicyRevision]: [
     MemberBanInputProjectionNode,
-  ]): ProjectionReduction<
-    MemberBanIntentProjectionNode,
-    MemberBanIntentProjectionDelta
-  > {
+  ]): MemberBanIntentProjectionNode {
     if (!this.isEmpty()) {
       throw new TypeError(
         "This can only be called on an empty projection node"
@@ -165,14 +154,10 @@ export class StandardMemberBanIntentProjectionNode implements MemberBanIntentPro
     for (const match of matches) {
       nextIntents = ListMultiMap.add(nextIntents, match.userID, match.policy);
     }
-    const nextNode = new StandardMemberBanIntentProjectionNode(
+    return new StandardMemberBanIntentProjectionNode(
       this.ulidFactory,
       nextIntents
     );
-    return {
-      downstreamDelta: this.diff(nextNode),
-      nextNode,
-    };
   }
 
   allMembersWithRules(): MemberPolicyMatches[] {

--- a/packages/matrix-protection-suite/src/Protection/StandardProtections/MemberBanSynchronisation/MemberBanIntentProjectionNode.ts
+++ b/packages/matrix-protection-suite/src/Protection/StandardProtections/MemberBanSynchronisation/MemberBanIntentProjectionNode.ts
@@ -39,14 +39,17 @@ export type MemberBanInputProjectionNode = ProjectionNode<
 > &
   MembershipPolicyRevision;
 
+export interface MemberBanIntentProjectionDelta {
+  ban: StringUserID[];
+  recall: StringUserID[];
+}
+
 // use add/remove for steady state intents
 // When the intent becomes effectual, matches will be removed
 // upstream and so this model will remain consistent
-export interface MemberBanIntentProjectionDelta {
+export interface MemberBanIntentProjectionStateDelta {
   add: MemberPolicyMatch[];
   remove: MemberPolicyMatch[];
-  ban: StringUserID[];
-  recall: StringUserID[];
 }
 
 function isPolicyRelevant(policy: LiteralPolicyRule | GlobPolicyRule): boolean {
@@ -59,7 +62,7 @@ function isPolicyRelevant(policy: LiteralPolicyRule | GlobPolicyRule): boolean {
 export type MemberBanIntentProjectionNode = ProjectionNode<
   [MemberBanInputProjectionNode],
   MemberBanIntentProjectionDelta,
-  undefined,
+  MemberBanIntentProjectionStateDelta,
   {
     allMembersWithRules(): MemberPolicyMatches[];
     allRulesMatchingMember(
@@ -71,8 +74,8 @@ export type MemberBanIntentProjectionNode = ProjectionNode<
 export const MemberBanIntentProjectionNodeHelper = Object.freeze({
   reduceMembershipPolicyDelta(
     input: MembershipPolicyRevisionDelta
-  ): Pick<MemberBanIntentProjectionDelta, "add" | "remove"> {
-    const output: Pick<MemberBanIntentProjectionDelta, "add" | "remove"> = {
+  ): MemberBanIntentProjectionStateDelta {
+    const output: MemberBanIntentProjectionStateDelta = {
       add: [],
       remove: [],
     };
@@ -89,7 +92,7 @@ export const MemberBanIntentProjectionNodeHelper = Object.freeze({
     return output;
   },
   reduceIntentDelta(
-    input: Pick<MemberBanIntentProjectionDelta, "add" | "remove">,
+    input: MemberBanIntentProjectionStateDelta,
     policies: PersistentMap<
       StringUserID,
       List<LiteralPolicyRule | GlobPolicyRule>
@@ -102,7 +105,6 @@ export const MemberBanIntentProjectionNodeHelper = Object.freeze({
       (rule) => rule.entity as StringUserID
     );
     return {
-      ...input,
       ban: intents.intend,
       recall: intents.recall,
     };
@@ -138,23 +140,28 @@ export class StandardMemberBanIntentProjectionNode implements MemberBanIntentPro
 
   reduceInput(
     input: ExtractInputDeltaShapes<[MemberBanInputProjectionNode]>
-  ): ProjectionNodeDelta<MemberBanIntentProjectionDelta, undefined> {
+  ): ProjectionNodeDelta<
+    MemberBanIntentProjectionDelta,
+    MemberBanIntentProjectionStateDelta
+  > {
+    const nodeStateDelta =
+      MemberBanIntentProjectionNodeHelper.reduceMembershipPolicyDelta(input);
     return {
       downstreamDelta: MemberBanIntentProjectionNodeHelper.reduceIntentDelta(
-        MemberBanIntentProjectionNodeHelper.reduceMembershipPolicyDelta(input),
+        nodeStateDelta,
         this.intents
       ),
-      nodeStateDelta: undefined,
+      nodeStateDelta,
     };
   }
 
   reduceDelta(
     projectionNodeDelta: ProjectionNodeDelta<
       MemberBanIntentProjectionDelta,
-      undefined
+      MemberBanIntentProjectionStateDelta
     >
   ): MemberBanIntentProjectionNode {
-    const input = projectionNodeDelta.downstreamDelta;
+    const input = projectionNodeDelta.nodeStateDelta;
     let nextIntents = this.intents;
     nextIntents = ListMultiMap.addValues(
       nextIntents,
@@ -174,7 +181,10 @@ export class StandardMemberBanIntentProjectionNode implements MemberBanIntentPro
 
   reduceInitialInputs([membershipPolicyRevision]: [
     MemberBanInputProjectionNode,
-  ]): ProjectionNodeDelta<MemberBanIntentProjectionDelta, undefined> {
+  ]): ProjectionNodeDelta<
+    MemberBanIntentProjectionDelta,
+    MemberBanIntentProjectionStateDelta
+  > {
     if (!this.isEmpty()) {
       throw new TypeError(
         "This can only be called on an empty projection node"
@@ -183,17 +193,21 @@ export class StandardMemberBanIntentProjectionNode implements MemberBanIntentPro
     const matches = membershipPolicyRevision
       .allMembersWithRules()
       .map((member) =>
-        member.policies.map((policy) => ({ userID: member.userID, policy }))
+        member.policies
+          .filter(isPolicyRelevant)
+          .map((policy) => ({ userID: member.userID, policy }))
       )
       .flat();
+    const nodeStateDelta = {
+      add: matches,
+      remove: [],
+    };
     return {
       downstreamDelta: {
-        add: matches,
-        ban: matches.map((match) => match.userID),
-        remove: [],
+        ban: [...new Set(matches.map((match) => match.userID))],
         recall: [],
       },
-      nodeStateDelta: undefined,
+      nodeStateDelta,
     };
   }
 

--- a/packages/matrix-protection-suite/src/Protection/StandardProtections/MemberBanSynchronisation/MemberBanIntentProjectionNode.ts
+++ b/packages/matrix-protection-suite/src/Protection/StandardProtections/MemberBanSynchronisation/MemberBanIntentProjectionNode.ts
@@ -11,6 +11,7 @@ import { ULID, ULIDFactory } from "ulidx";
 import {
   ExtractInputDeltaShapes,
   ProjectionNode,
+  ProjectionNodeDelta,
 } from "../../../Projection/ProjectionNode";
 import {
   MemberPolicyMatch,
@@ -33,7 +34,8 @@ import { ListMultiMap } from "../../../Projection/ListMultiMap";
  */
 export type MemberBanInputProjectionNode = ProjectionNode<
   never[],
-  MembershipPolicyRevisionDelta
+  MembershipPolicyRevisionDelta,
+  undefined
 > &
   MembershipPolicyRevision;
 
@@ -57,6 +59,7 @@ function isPolicyRelevant(policy: LiteralPolicyRule | GlobPolicyRule): boolean {
 export type MemberBanIntentProjectionNode = ProjectionNode<
   [MemberBanInputProjectionNode],
   MemberBanIntentProjectionDelta,
+  undefined,
   {
     allMembersWithRules(): MemberPolicyMatches[];
     allRulesMatchingMember(
@@ -135,16 +138,23 @@ export class StandardMemberBanIntentProjectionNode implements MemberBanIntentPro
 
   reduceInput(
     input: ExtractInputDeltaShapes<[MemberBanInputProjectionNode]>
-  ): MemberBanIntentProjectionDelta {
-    return MemberBanIntentProjectionNodeHelper.reduceIntentDelta(
-      MemberBanIntentProjectionNodeHelper.reduceMembershipPolicyDelta(input),
-      this.intents
-    );
+  ): ProjectionNodeDelta<MemberBanIntentProjectionDelta, undefined> {
+    return {
+      downstreamDelta: MemberBanIntentProjectionNodeHelper.reduceIntentDelta(
+        MemberBanIntentProjectionNodeHelper.reduceMembershipPolicyDelta(input),
+        this.intents
+      ),
+      nodeStateDelta: undefined,
+    };
   }
 
   reduceDelta(
-    input: MemberBanIntentProjectionDelta
-  ): StandardMemberBanIntentProjectionNode {
+    projectionNodeDelta: ProjectionNodeDelta<
+      MemberBanIntentProjectionDelta,
+      undefined
+    >
+  ): MemberBanIntentProjectionNode {
+    const input = projectionNodeDelta.downstreamDelta;
     let nextIntents = this.intents;
     nextIntents = ListMultiMap.addValues(
       nextIntents,
@@ -164,7 +174,7 @@ export class StandardMemberBanIntentProjectionNode implements MemberBanIntentPro
 
   reduceInitialInputs([membershipPolicyRevision]: [
     MemberBanInputProjectionNode,
-  ]): MemberBanIntentProjectionDelta {
+  ]): ProjectionNodeDelta<MemberBanIntentProjectionDelta, undefined> {
     if (!this.isEmpty()) {
       throw new TypeError(
         "This can only be called on an empty projection node"
@@ -177,10 +187,13 @@ export class StandardMemberBanIntentProjectionNode implements MemberBanIntentPro
       )
       .flat();
     return {
-      add: matches,
-      ban: matches.map((match) => match.userID),
-      remove: [],
-      recall: [],
+      downstreamDelta: {
+        add: matches,
+        ban: matches.map((match) => match.userID),
+        remove: [],
+        recall: [],
+      },
+      nodeStateDelta: undefined,
     };
   }
 

--- a/packages/matrix-protection-suite/src/Protection/StandardProtections/ServerBanSynchronisation/PolicyListBridgeProjection.ts
+++ b/packages/matrix-protection-suite/src/Protection/StandardProtections/ServerBanSynchronisation/PolicyListBridgeProjection.ts
@@ -14,5 +14,6 @@ import { ProjectionNode } from "../../../Projection/ProjectionNode";
 export type PolicyListBridgeProjectionNode = ProjectionNode<
   [],
   PolicyRuleChange[],
+  undefined,
   PolicyListRevision
 >;

--- a/packages/matrix-protection-suite/src/Protection/StandardProtections/ServerBanSynchronisation/PolicyListBridgeProjection.ts
+++ b/packages/matrix-protection-suite/src/Protection/StandardProtections/ServerBanSynchronisation/PolicyListBridgeProjection.ts
@@ -14,6 +14,5 @@ import { ProjectionNode } from "../../../Projection/ProjectionNode";
 export type PolicyListBridgeProjectionNode = ProjectionNode<
   [],
   PolicyRuleChange[],
-  undefined,
   PolicyListRevision
 >;

--- a/packages/matrix-protection-suite/src/Protection/StandardProtections/ServerBanSynchronisation/ServerACLSynchronisationCapability.test.ts
+++ b/packages/matrix-protection-suite/src/Protection/StandardProtections/ServerBanSynchronisation/ServerACLSynchronisationCapability.test.ts
@@ -47,16 +47,14 @@ test("ACL compilation works and does not ban our server", async function () {
       content: UnredactedPolicyContent;
     }
   ).expect("Should be able to parse the policy rule");
-  const nodeWithBans = emptyNode.reduceDelta(
-    emptyNode.reduceInput(
-      [banPolicyRule, ourBanPolicyRule].map((policy) => ({
-        rule: policy,
-        sender: policy.sourceEvent.sender,
-        event: policy.sourceEvent,
-        changeType: PolicyRuleChangeType.Added,
-      }))
-    )
-  );
+  const nodeWithBans = emptyNode.reduceInput(
+    [banPolicyRule, ourBanPolicyRule].map((policy) => ({
+      rule: policy,
+      sender: policy.sourceEvent.sender,
+      event: policy.sourceEvent,
+      changeType: PolicyRuleChangeType.Added,
+    }))
+  ).nextNode;
   const acl = compileServerACL(ourServerName, nodeWithBans).safeAclContent();
   expect(acl.deny?.at(0)).toBe(badServer);
   expect(acl.deny?.length).toBe(1);

--- a/packages/matrix-protection-suite/src/Protection/StandardProtections/ServerBanSynchronisation/ServerACLSynchronisationCapability.test.ts
+++ b/packages/matrix-protection-suite/src/Protection/StandardProtections/ServerBanSynchronisation/ServerACLSynchronisationCapability.test.ts
@@ -54,7 +54,7 @@ test("ACL compilation works and does not ban our server", async function () {
       event: policy.sourceEvent,
       changeType: PolicyRuleChangeType.Added,
     }))
-  ).nextNode;
+  );
   const acl = compileServerACL(ourServerName, nodeWithBans).safeAclContent();
   expect(acl.deny?.at(0)).toBe(badServer);
   expect(acl.deny?.length).toBe(1);

--- a/packages/matrix-protection-suite/src/Protection/StandardProtections/ServerBanSynchronisation/ServerBanIntentProjection.ts
+++ b/packages/matrix-protection-suite/src/Protection/StandardProtections/ServerBanSynchronisation/ServerBanIntentProjection.ts
@@ -34,10 +34,10 @@ export class StandardServerBanIntentProjection
   ) {
     const node =
       StandardServerBanIntentProjectionNode.create(monotonicFactory());
-    const delta = node.reduceInitialInputs([
+    const reduction = node.reduceInitialInputs([
       policyListRevisionIssuer.currentRevision as unknown as PolicyListBridgeProjectionNode,
     ]);
-    super(node.reduceDelta(delta));
+    super(reduction.nextNode);
     this.policyListRevisionIssuer.on("revision", this.handleUpstreamRevision);
   }
 

--- a/packages/matrix-protection-suite/src/Protection/StandardProtections/ServerBanSynchronisation/ServerBanIntentProjection.ts
+++ b/packages/matrix-protection-suite/src/Protection/StandardProtections/ServerBanSynchronisation/ServerBanIntentProjection.ts
@@ -34,10 +34,10 @@ export class StandardServerBanIntentProjection
   ) {
     const node =
       StandardServerBanIntentProjectionNode.create(monotonicFactory());
-    const reduction = node.reduceInitialInputs([
+    const initialNode = node.reduceInitialInputs([
       policyListRevisionIssuer.currentRevision as unknown as PolicyListBridgeProjectionNode,
     ]);
-    super(reduction.nextNode);
+    super(initialNode);
     this.policyListRevisionIssuer.on("revision", this.handleUpstreamRevision);
   }
 

--- a/packages/matrix-protection-suite/src/Protection/StandardProtections/ServerBanSynchronisation/ServerBanIntentProjectionNode.ts
+++ b/packages/matrix-protection-suite/src/Protection/StandardProtections/ServerBanSynchronisation/ServerBanIntentProjectionNode.ts
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 Gnuxie <Gnuxie@protonmail.com>
+// SPDX-FileCopyrightText: 2025 - 2026 Gnuxie <Gnuxie@protonmail.com>
 //
 // SPDX-License-Identifier: Apache-2.0
 //
@@ -10,7 +10,7 @@
 import { StringServerName } from "@the-draupnir-project/matrix-basic-types";
 import {
   ProjectionNode,
-  ProjectionNodeDelta,
+  ProjectionReduction,
 } from "../../../Projection/ProjectionNode";
 import { PolicyListBridgeProjectionNode } from "./PolicyListBridgeProjection";
 import {
@@ -33,10 +33,10 @@ export type ServerBanIntentProjectionDelta = {
   recall: StringServerName[];
 };
 
-export type ServerBanIntentProjectionStateDelta = {
-  add: (LiteralPolicyRule | GlobPolicyRule)[];
-  remove: (LiteralPolicyRule | GlobPolicyRule)[];
-};
+type ServerBanIntentMap = PersistentMap<
+  StringServerName,
+  List<LiteralPolicyRule | GlobPolicyRule>
+>;
 
 // is there a way that we can adapt this so that it can possibly be swapped
 // to a lazy ban style protection if acls become exhausted.
@@ -44,77 +44,17 @@ export type ServerBanIntentProjectionStateDelta = {
 export type ServerBanIntentProjectionNode = ProjectionNode<
   [PolicyListBridgeProjectionNode],
   ServerBanIntentProjectionDelta,
-  ServerBanIntentProjectionStateDelta,
   {
     deny: StringServerName[];
+    isServerDenied(serverName: StringServerName): boolean;
   }
 >;
-
-export const ServerBanIntentProjectionHelper = Object.freeze({
-  reducePolicyDelta(
-    input: PolicyRuleChange[]
-  ): ServerBanIntentProjectionStateDelta {
-    const output: ServerBanIntentProjectionStateDelta = {
-      add: [],
-      remove: [],
-    };
-    for (const change of input) {
-      if (change.rule.kind !== PolicyRuleType.Server) {
-        continue;
-      } else if (change.rule.matchType === PolicyRuleMatchType.HashedLiteral) {
-        continue;
-      }
-      switch (change.changeType) {
-        case PolicyRuleChangeType.Added:
-        case PolicyRuleChangeType.RevealedLiteral: {
-          output.add.push(change.rule);
-          break;
-        }
-        case PolicyRuleChangeType.Modified: {
-          output.add.push(change.rule);
-          if (change.previousRule === undefined) {
-            throw new TypeError("Things are very wrong");
-          }
-          output.remove.push(change.previousRule as LiteralPolicyRule);
-          break;
-        }
-        case PolicyRuleChangeType.Removed: {
-          output.remove.push(change.rule);
-          break;
-        }
-      }
-    }
-    return output;
-  },
-
-  reduceIntentDelta(
-    input: ServerBanIntentProjectionStateDelta,
-    policies: PersistentMap<
-      StringServerName,
-      List<GlobPolicyRule | LiteralPolicyRule>
-    >
-  ): ServerBanIntentProjectionDelta {
-    const intents = ListMultiMap.deriveIntents(
-      policies,
-      input.add,
-      input.remove,
-      (rule) => rule.entity as StringServerName
-    );
-    return {
-      deny: intents.intend,
-      recall: intents.recall,
-    };
-  },
-});
 
 export class StandardServerBanIntentProjectionNode implements ServerBanIntentProjectionNode {
   public readonly ulid: ULID;
   constructor(
     private readonly ulidFactory: ULIDFactory,
-    private readonly policies: PersistentMap<
-      StringServerName,
-      List<LiteralPolicyRule | GlobPolicyRule>
-    >
+    private readonly policies: ServerBanIntentMap
   ) {
     this.ulid = ulidFactory();
   }
@@ -128,28 +68,95 @@ export class StandardServerBanIntentProjectionNode implements ServerBanIntentPro
     );
   }
 
+  diff(
+    nextNode: ServerBanIntentProjectionNode
+  ): ServerBanIntentProjectionDelta {
+    const deny: StringServerName[] = [];
+    const recall: StringServerName[] = [];
+    for (const serverName of nextNode.deny) {
+      if (!this.isServerDenied(serverName)) {
+        deny.push(serverName);
+      }
+    }
+    for (const serverName of this.policies.keys()) {
+      if (!nextNode.isServerDenied(serverName)) {
+        recall.push(serverName);
+      }
+    }
+    return { deny, recall };
+  }
+
   reduceInput(
     input: PolicyRuleChange[]
-  ): ProjectionNodeDelta<
-    ServerBanIntentProjectionDelta,
-    ServerBanIntentProjectionStateDelta
+  ): ProjectionReduction<
+    ServerBanIntentProjectionNode,
+    ServerBanIntentProjectionDelta
   > {
-    const nodeStateDelta =
-      ServerBanIntentProjectionHelper.reducePolicyDelta(input);
+    let nextPolicies = this.policies;
+    for (const change of input) {
+      if (
+        change.rule.kind !== PolicyRuleType.Server ||
+        change.rule.matchType === PolicyRuleMatchType.HashedLiteral
+      ) {
+        continue;
+      }
+      switch (change.changeType) {
+        case PolicyRuleChangeType.Added:
+        case PolicyRuleChangeType.RevealedLiteral: {
+          nextPolicies = ListMultiMap.add(
+            nextPolicies,
+            change.rule.entity as StringServerName,
+            change.rule
+          );
+          break;
+        }
+        case PolicyRuleChangeType.Modified: {
+          if (change.previousRule === undefined) {
+            throw new TypeError("Things are very wrong");
+          }
+          nextPolicies = ListMultiMap.add(
+            nextPolicies,
+            change.rule.entity as StringServerName,
+            change.rule
+          );
+          if (
+            change.previousRule.kind !== PolicyRuleType.Server ||
+            change.previousRule.matchType === PolicyRuleMatchType.HashedLiteral
+          ) {
+            break;
+          }
+          nextPolicies = ListMultiMap.remove(
+            nextPolicies,
+            change.previousRule.entity as StringServerName,
+            change.previousRule
+          );
+          break;
+        }
+        case PolicyRuleChangeType.Removed: {
+          nextPolicies = ListMultiMap.remove(
+            nextPolicies,
+            change.rule.entity as StringServerName,
+            change.rule
+          );
+          break;
+        }
+      }
+    }
+    const nextNode = new StandardServerBanIntentProjectionNode(
+      this.ulidFactory,
+      nextPolicies
+    );
     return {
-      downstreamDelta: ServerBanIntentProjectionHelper.reduceIntentDelta(
-        nodeStateDelta,
-        this.policies
-      ),
-      nodeStateDelta,
+      downstreamDelta: this.diff(nextNode),
+      nextNode,
     };
   }
 
   reduceInitialInputs([policyListRevision]: [
     PolicyListBridgeProjectionNode,
-  ]): ProjectionNodeDelta<
-    ServerBanIntentProjectionDelta,
-    ServerBanIntentProjectionStateDelta
+  ]): ProjectionReduction<
+    ServerBanIntentProjectionNode,
+    ServerBanIntentProjectionDelta
   > {
     if (!this.isEmpty()) {
       throw new TypeError("Cannot reduce initial inputs when inialised");
@@ -164,18 +171,24 @@ export class StandardServerBanIntentProjectionNode implements ServerBanIntentPro
         Recommendation.Takedown
       ),
     ].filter((rule) => rule.matchType !== PolicyRuleMatchType.HashedLiteral);
-    const names = new Set(serverPolicies.map((policy) => policy.entity));
-    const downstreamDelta = {
-      deny: [...names] as StringServerName[],
-      recall: [],
-    };
-    const nodeStateDelta = {
-      add: serverPolicies,
-      remove: [],
-    };
+    let nextPolicies = PersistentMap<
+      StringServerName,
+      List<LiteralPolicyRule | GlobPolicyRule>
+    >();
+    for (const policy of serverPolicies) {
+      nextPolicies = ListMultiMap.add(
+        nextPolicies,
+        policy.entity as StringServerName,
+        policy
+      );
+    }
+    const nextNode = new StandardServerBanIntentProjectionNode(
+      this.ulidFactory,
+      nextPolicies
+    );
     return {
-      downstreamDelta,
-      nodeStateDelta,
+      downstreamDelta: this.diff(nextNode),
+      nextNode,
     };
   }
 
@@ -183,30 +196,11 @@ export class StandardServerBanIntentProjectionNode implements ServerBanIntentPro
     return this.policies.size === 0;
   }
 
-  reduceDelta({
-    nodeStateDelta: input,
-  }: ProjectionNodeDelta<
-    ServerBanIntentProjectionDelta,
-    ServerBanIntentProjectionStateDelta
-  >): ServerBanIntentProjectionNode {
-    let nextPolicies = this.policies;
-    nextPolicies = ListMultiMap.addValues(
-      nextPolicies,
-      input.add,
-      (rule) => rule.entity as StringServerName
-    );
-    nextPolicies = ListMultiMap.removeValues(
-      nextPolicies,
-      input.remove,
-      (rule) => rule.entity as StringServerName
-    );
-    return new StandardServerBanIntentProjectionNode(
-      this.ulidFactory,
-      nextPolicies
-    );
-  }
-
   get deny(): StringServerName[] {
     return [...this.policies.keys()];
+  }
+
+  isServerDenied(serverName: StringServerName): boolean {
+    return this.policies.has(serverName);
   }
 }

--- a/packages/matrix-protection-suite/src/Protection/StandardProtections/ServerBanSynchronisation/ServerBanIntentProjectionNode.ts
+++ b/packages/matrix-protection-suite/src/Protection/StandardProtections/ServerBanSynchronisation/ServerBanIntentProjectionNode.ts
@@ -31,6 +31,9 @@ import { ListMultiMap } from "../../../Projection/ListMultiMap";
 export type ServerBanIntentProjectionDelta = {
   deny: StringServerName[];
   recall: StringServerName[];
+};
+
+export type ServerBanIntentProjectionStateDelta = {
   add: (LiteralPolicyRule | GlobPolicyRule)[];
   remove: (LiteralPolicyRule | GlobPolicyRule)[];
 };
@@ -41,7 +44,7 @@ export type ServerBanIntentProjectionDelta = {
 export type ServerBanIntentProjectionNode = ProjectionNode<
   [PolicyListBridgeProjectionNode],
   ServerBanIntentProjectionDelta,
-  undefined,
+  ServerBanIntentProjectionStateDelta,
   {
     deny: StringServerName[];
   }
@@ -50,11 +53,11 @@ export type ServerBanIntentProjectionNode = ProjectionNode<
 export const ServerBanIntentProjectionHelper = Object.freeze({
   reducePolicyDelta(
     input: PolicyRuleChange[]
-  ): Pick<ServerBanIntentProjectionDelta, "add" | "remove"> {
-    const output: Pick<ServerBanIntentProjectionDelta, "add" | "remove"> = {
+  ): ServerBanIntentProjectionStateDelta {
+    const output: ServerBanIntentProjectionStateDelta = {
       add: [],
       remove: [],
-    } satisfies Pick<ServerBanIntentProjectionDelta, "add" | "remove">;
+    };
     for (const change of input) {
       if (change.rule.kind !== PolicyRuleType.Server) {
         continue;
@@ -85,7 +88,7 @@ export const ServerBanIntentProjectionHelper = Object.freeze({
   },
 
   reduceIntentDelta(
-    input: Pick<ServerBanIntentProjectionDelta, "add" | "remove">,
+    input: ServerBanIntentProjectionStateDelta,
     policies: PersistentMap<
       StringServerName,
       List<GlobPolicyRule | LiteralPolicyRule>
@@ -98,7 +101,6 @@ export const ServerBanIntentProjectionHelper = Object.freeze({
       (rule) => rule.entity as StringServerName
     );
     return {
-      ...input,
       deny: intents.intend,
       recall: intents.recall,
     };
@@ -128,19 +130,27 @@ export class StandardServerBanIntentProjectionNode implements ServerBanIntentPro
 
   reduceInput(
     input: PolicyRuleChange[]
-  ): ProjectionNodeDelta<ServerBanIntentProjectionDelta, undefined> {
+  ): ProjectionNodeDelta<
+    ServerBanIntentProjectionDelta,
+    ServerBanIntentProjectionStateDelta
+  > {
+    const nodeStateDelta =
+      ServerBanIntentProjectionHelper.reducePolicyDelta(input);
     return {
       downstreamDelta: ServerBanIntentProjectionHelper.reduceIntentDelta(
-        ServerBanIntentProjectionHelper.reducePolicyDelta(input),
+        nodeStateDelta,
         this.policies
       ),
-      nodeStateDelta: undefined,
+      nodeStateDelta,
     };
   }
 
   reduceInitialInputs([policyListRevision]: [
     PolicyListBridgeProjectionNode,
-  ]): ProjectionNodeDelta<ServerBanIntentProjectionDelta, undefined> {
+  ]): ProjectionNodeDelta<
+    ServerBanIntentProjectionDelta,
+    ServerBanIntentProjectionStateDelta
+  > {
     if (!this.isEmpty()) {
       throw new TypeError("Cannot reduce initial inputs when inialised");
     }
@@ -156,14 +166,16 @@ export class StandardServerBanIntentProjectionNode implements ServerBanIntentPro
     ].filter((rule) => rule.matchType !== PolicyRuleMatchType.HashedLiteral);
     const names = new Set(serverPolicies.map((policy) => policy.entity));
     const downstreamDelta = {
-      add: serverPolicies,
       deny: [...names] as StringServerName[],
-      remove: [],
       recall: [],
+    };
+    const nodeStateDelta = {
+      add: serverPolicies,
+      remove: [],
     };
     return {
       downstreamDelta,
-      nodeStateDelta: undefined,
+      nodeStateDelta,
     };
   }
 
@@ -172,10 +184,10 @@ export class StandardServerBanIntentProjectionNode implements ServerBanIntentPro
   }
 
   reduceDelta({
-    downstreamDelta: input,
+    nodeStateDelta: input,
   }: ProjectionNodeDelta<
     ServerBanIntentProjectionDelta,
-    undefined
+    ServerBanIntentProjectionStateDelta
   >): ServerBanIntentProjectionNode {
     let nextPolicies = this.policies;
     nextPolicies = ListMultiMap.addValues(

--- a/packages/matrix-protection-suite/src/Protection/StandardProtections/ServerBanSynchronisation/ServerBanIntentProjectionNode.ts
+++ b/packages/matrix-protection-suite/src/Protection/StandardProtections/ServerBanSynchronisation/ServerBanIntentProjectionNode.ts
@@ -8,7 +8,10 @@
 // </text>
 
 import { StringServerName } from "@the-draupnir-project/matrix-basic-types";
-import { ProjectionNode } from "../../../Projection/ProjectionNode";
+import {
+  ProjectionNode,
+  ProjectionNodeDelta,
+} from "../../../Projection/ProjectionNode";
 import { PolicyListBridgeProjectionNode } from "./PolicyListBridgeProjection";
 import {
   PolicyRuleChange,
@@ -38,6 +41,7 @@ export type ServerBanIntentProjectionDelta = {
 export type ServerBanIntentProjectionNode = ProjectionNode<
   [PolicyListBridgeProjectionNode],
   ServerBanIntentProjectionDelta,
+  undefined,
   {
     deny: StringServerName[];
   }
@@ -122,15 +126,21 @@ export class StandardServerBanIntentProjectionNode implements ServerBanIntentPro
     );
   }
 
-  reduceInput(input: PolicyRuleChange[]): ServerBanIntentProjectionDelta {
-    return ServerBanIntentProjectionHelper.reduceIntentDelta(
-      ServerBanIntentProjectionHelper.reducePolicyDelta(input),
-      this.policies
-    );
+  reduceInput(
+    input: PolicyRuleChange[]
+  ): ProjectionNodeDelta<ServerBanIntentProjectionDelta, undefined> {
+    return {
+      downstreamDelta: ServerBanIntentProjectionHelper.reduceIntentDelta(
+        ServerBanIntentProjectionHelper.reducePolicyDelta(input),
+        this.policies
+      ),
+      nodeStateDelta: undefined,
+    };
   }
+
   reduceInitialInputs([policyListRevision]: [
     PolicyListBridgeProjectionNode,
-  ]): ServerBanIntentProjectionDelta {
+  ]): ProjectionNodeDelta<ServerBanIntentProjectionDelta, undefined> {
     if (!this.isEmpty()) {
       throw new TypeError("Cannot reduce initial inputs when inialised");
     }
@@ -145,11 +155,15 @@ export class StandardServerBanIntentProjectionNode implements ServerBanIntentPro
       ),
     ].filter((rule) => rule.matchType !== PolicyRuleMatchType.HashedLiteral);
     const names = new Set(serverPolicies.map((policy) => policy.entity));
-    return {
+    const downstreamDelta = {
       add: serverPolicies,
       deny: [...names] as StringServerName[],
       remove: [],
       recall: [],
+    };
+    return {
+      downstreamDelta,
+      nodeStateDelta: undefined,
     };
   }
 
@@ -157,9 +171,12 @@ export class StandardServerBanIntentProjectionNode implements ServerBanIntentPro
     return this.policies.size === 0;
   }
 
-  reduceDelta(
-    input: ServerBanIntentProjectionDelta
-  ): ServerBanIntentProjectionNode {
+  reduceDelta({
+    downstreamDelta: input,
+  }: ProjectionNodeDelta<
+    ServerBanIntentProjectionDelta,
+    undefined
+  >): ServerBanIntentProjectionNode {
     let nextPolicies = this.policies;
     nextPolicies = ListMultiMap.addValues(
       nextPolicies,

--- a/packages/matrix-protection-suite/src/Protection/StandardProtections/ServerBanSynchronisation/ServerBanIntentProjectionNode.ts
+++ b/packages/matrix-protection-suite/src/Protection/StandardProtections/ServerBanSynchronisation/ServerBanIntentProjectionNode.ts
@@ -8,10 +8,7 @@
 // </text>
 
 import { StringServerName } from "@the-draupnir-project/matrix-basic-types";
-import {
-  ProjectionNode,
-  ProjectionReduction,
-} from "../../../Projection/ProjectionNode";
+import { ProjectionNode } from "../../../Projection/ProjectionNode";
 import { PolicyListBridgeProjectionNode } from "./PolicyListBridgeProjection";
 import {
   PolicyRuleChange,
@@ -86,12 +83,7 @@ export class StandardServerBanIntentProjectionNode implements ServerBanIntentPro
     return { deny, recall };
   }
 
-  reduceInput(
-    input: PolicyRuleChange[]
-  ): ProjectionReduction<
-    ServerBanIntentProjectionNode,
-    ServerBanIntentProjectionDelta
-  > {
+  reduceInput(input: PolicyRuleChange[]): ServerBanIntentProjectionNode {
     let nextPolicies = this.policies;
     for (const change of input) {
       if (
@@ -142,22 +134,15 @@ export class StandardServerBanIntentProjectionNode implements ServerBanIntentPro
         }
       }
     }
-    const nextNode = new StandardServerBanIntentProjectionNode(
+    return new StandardServerBanIntentProjectionNode(
       this.ulidFactory,
       nextPolicies
     );
-    return {
-      downstreamDelta: this.diff(nextNode),
-      nextNode,
-    };
   }
 
   reduceInitialInputs([policyListRevision]: [
     PolicyListBridgeProjectionNode,
-  ]): ProjectionReduction<
-    ServerBanIntentProjectionNode,
-    ServerBanIntentProjectionDelta
-  > {
+  ]): ServerBanIntentProjectionNode {
     if (!this.isEmpty()) {
       throw new TypeError("Cannot reduce initial inputs when inialised");
     }
@@ -182,14 +167,10 @@ export class StandardServerBanIntentProjectionNode implements ServerBanIntentPro
         policy
       );
     }
-    const nextNode = new StandardServerBanIntentProjectionNode(
+    return new StandardServerBanIntentProjectionNode(
       this.ulidFactory,
       nextPolicies
     );
-    return {
-      downstreamDelta: this.diff(nextNode),
-      nextNode,
-    };
   }
 
   isEmpty(): boolean {


### PR DESCRIPTION
We figured out while working on https://github.com/the-draupnir-project/Draupnir/pull/1099 that actually in both cases if delta reducers are incorrect and get fixed, then downstream nodes have to use `reduceRebuild`.

The single-step projection nodes are much simpler though and don't leak internal state into the diff.

Closes https://github.com/the-draupnir-project/planning/issues/123