### PR TITLE
Split `SemanticType` into two steps, describe and verify.

### DIFF
--- a/packages/matrix-protection-suite/src/Interface/SemanticType.ts
+++ b/packages/matrix-protection-suite/src/Interface/SemanticType.ts
@@ -1,44 +1,59 @@
-// SPDX-FileCopyrightText: 2025 Gnuxie <Gnuxie@protonmail.com>
+// SPDX-FileCopyrightText: 2025 - 2026 Gnuxie <Gnuxie@protonmail.com>
 //
 // SPDX-License-Identifier: Apache-2.0
 
 import { Result } from "@gnuxie/typescript-result";
 
-export type InvariantCheck<Subject> = Invariant<Subject>;
-
-export interface Invariant<Subject> {
-  semanticTypeName: string;
-  lawName: string;
-  what: string;
-  why: string;
-  law: string;
-  check: (makeSubject: LawSubjectFactory<Subject>) => void | Promise<void>;
-}
-
 export type LawSubjectFactory<Subject> = () => Promise<Result<Subject>>;
 
-export interface LawDescription<Subject> {
+export type SemanticCheck<Subject> = (
+  makeSubject: LawSubjectFactory<Subject>
+) => void | Promise<void>;
+
+export interface SemanticDescription {
   what: string;
   why: string;
-  law: string;
-  check: (makeSubject: LawSubjectFactory<Subject>) => void | Promise<void>;
+  when?: string;
+  law?: string;
 }
 
-export interface SemanticType<Subject> {
+export interface Semantic {
+  semanticTypeName: string;
   name: string;
-  invariants: Array<Invariant<Subject>>;
+  what: string;
+  why: string;
+  when?: string;
+  law?: string;
+}
+
+export interface VerifiableSemantic<Subject> extends Semantic {
+  check: SemanticCheck<Subject>;
+}
+
+export interface SemanticType<Subject, SemanticNames extends string = string> {
+  name: string;
+  semantics: Array<Semantic>;
+  verify(
+    checks: Partial<Record<SemanticNames, SemanticCheck<Subject>>>
+  ): VerifiableSemanticType<Subject>;
+}
+
+export interface VerifiableSemanticType<Subject> {
+  semanticType: SemanticType<Subject>;
+  verifiableSemantics: Array<VerifiableSemantic<Subject>>;
   check(makeSubject: LawSubjectFactory<Subject>): Promise<void>;
 }
 
 /**
- * A semantic type is used to describe the expected behavior of a type beyond its shape.
- * At the moment invariants can be specified through the `Law` method.
- * This adds structure to important behavioural contracts that would otherwise be
- * placed loosely in unit tests with no organisation.
+ * A semantic type is used to describe the expected behavior of a type beyond
+ * its shape. Semantic declarations document the behavioural contract directly
+ * at the interface, while verification can be attached later for any subset of
+ * those semantics. Before we added the semantic type abstraction, these checks
+ * would be placed loosely in unit tests with no organisation on an adhoc basis.
  *
- * Another important feature of the invariant law is that they describe why they
- * are included in the sematic type which helps negotiating their removal if
- * the underlying abstraction changes.
+ * Another important feature of semantic type is to they describe why semantics
+ * included, which helps negotiating their removal if the underlying abstraction
+ * changes.
  *
  * Critically the laws as opposed to tests are also defined against the
  * interface and not any single concrete implementation. But all implementations
@@ -50,34 +65,81 @@ export interface SemanticType<Subject> {
  */
 export function SemanticType<Subject>(name: string) {
   return {
-    Law<Laws extends Record<string, LawDescription<Subject>>>(
-      laws: Laws
-    ): SemanticType<Subject> {
-      return describeSemanticType<Subject, Laws>({ name, ...laws });
+    declare<Semantics extends Record<string, SemanticDescription>>(
+      semantics: Semantics
+    ): SemanticType<Subject, keyof Semantics & string> {
+      return describeSemanticType<Subject, keyof Semantics & string>({
+        name,
+        semantics,
+      });
+    },
+    Law<
+      Laws extends Record<
+        string,
+        SemanticDescription & { check: SemanticCheck<Subject> }
+      >,
+    >(laws: Laws): VerifiableSemanticType<Subject> {
+      const semantics = Object.fromEntries(
+        Object.entries(laws).map(
+          ([semanticName, { check: _check, ...semantic }]) => [
+            semanticName,
+            semantic,
+          ]
+        )
+      ) as Record<string, SemanticDescription>;
+      return describeSemanticType<Subject, keyof Laws & string>({
+        name,
+        semantics,
+      }).verify(
+        Object.fromEntries(
+          Object.entries(laws).map(([semanticName, law]) => [
+            semanticName,
+            law.check,
+          ])
+        ) as Partial<Record<keyof Laws & string, SemanticCheck<Subject>>>
+      );
     },
   };
 }
 
 export function describeSemanticType<
   Subject,
-  Laws extends Record<string, LawDescription<Subject>>,
->(description: { name: string } & Laws): SemanticType<Subject> {
-  const { name, ...rest } = description;
-  const lawDescriptions = rest as Record<string, LawDescription<Subject>>;
-  const invariants: Array<Invariant<Subject>> = Object.entries(
-    lawDescriptions
-  ).map(([lawName, lawDescription]) => ({
-    semanticTypeName: name,
-    lawName,
-    ...lawDescription,
-  }));
-  return {
-    name,
-    invariants,
-    async check(makeSubject) {
-      for (const law of invariants) {
-        await law.check(makeSubject);
-      }
+  SemanticNames extends string,
+>(description: {
+  name: string;
+  semantics: Record<SemanticNames, SemanticDescription>;
+}): SemanticType<Subject, SemanticNames> {
+  const semanticEntries = Object.entries(description.semantics) as Array<
+    [SemanticNames, SemanticDescription]
+  >;
+  const semantics: Array<Semantic> = semanticEntries.map(
+    ([semanticName, semanticDescription]) => ({
+      semanticTypeName: description.name,
+      name: semanticName,
+      ...semanticDescription,
+    })
+  );
+  const semanticType: SemanticType<Subject, SemanticNames> = {
+    name: description.name,
+    semantics,
+    verify(
+      checks: Partial<Record<SemanticNames, SemanticCheck<Subject>>>
+    ): VerifiableSemanticType<Subject> {
+      const verifiableSemantics: Array<VerifiableSemantic<Subject>> =
+        semantics.flatMap((semantic) => {
+          const check = checks[semantic.name as SemanticNames];
+          return check === undefined ? [] : [{ ...semantic, check }];
+        });
+      return {
+        semanticType,
+        verifiableSemantics,
+        async check(makeSubject) {
+          for (const semantic of verifiableSemantics) {
+            await semantic.check(makeSubject);
+          }
+        },
+      };
     },
   };
+  return semanticType;
 }

--- a/packages/matrix-protection-suite/src/Protection/HandleRegistry/HandleRegistry.ts
+++ b/packages/matrix-protection-suite/src/Protection/HandleRegistry/HandleRegistry.ts
@@ -35,12 +35,35 @@ export interface HandleRegistry<
 
 export const HandleRegistrySemantics = SemanticType<HandleRegistryDescription>(
   "HandleRegistry"
-).Law({
-  establishHandles: {
-    what: "When registerPluginHandles is called, plugins will later receive calls for their handles",
-    why: "Provides the hook point for plugins to register with handles",
-    law: "For plugin P and handle H, registering plugin will result in handle H being called on plugin when invoked",
-    async check(makeSubject) {
+)
+  .declare({
+    establishHandles: {
+      what: "When registerPluginHandles is called, plugins will later receive calls for their handles",
+      why: "Provides the hook point for plugins to register with handles",
+      when: "After a plugin has been registered and before it is removed or the registry is disposed",
+      law: "For plugin P and handle H, registering plugin will result in handle H being called on plugin when invoked",
+    },
+    pluginRemoval: {
+      what: "Handles will no longer be called on plugins that are unregistered",
+      why: "Make sure that plugins can be cleanly removed from the system",
+      when: "After removePluginHandles has been called for a plugin",
+      law: "For plugin P and handle H, after unregistering P, H will no longer be called on P",
+    },
+    unaryHandleRegistration: {
+      what: "Plugin registration is unary, handles will not be called multiple times as a result of multiple registration",
+      why: "Prevents bugs from multiple registration",
+      when: "When the same plugin is registered more than once",
+      law: "For a plugin P, and handle H, calling registerHandles(P) twice will result in H of P being called exactly once only",
+    },
+    disposable: {
+      what: "HandleRegistry un-registers all plugins on disposal",
+      why: "Prevents resource leaks from HandleRegistry instances",
+      when: "After disposing the HandleRegistry",
+      law: "For plugin P and handle H, after disposing the HandleRegistry, H will no longer be called on P",
+    },
+  })
+  .verify({
+    async establishHandles(makeSubject) {
       const description = (await makeSubject()).expect(
         "Should be able to make the subject"
       );
@@ -85,12 +108,7 @@ export const HandleRegistrySemantics = SemanticType<HandleRegistryDescription>(
         throw new TypeError("Registered handle was not invoked after publish");
       }
     },
-  },
-  pluginRemoval: {
-    what: "Handles will no longer be called on plugins that are unregistered",
-    why: "Make sure that plugins can be cleanly removed from the system",
-    law: "For plugin P and handle H, after unregistering P, H will no longer be called on P",
-    async check(makeSubject) {
+    async pluginRemoval(makeSubject) {
       const description = (await makeSubject()).expect(
         "Should be able to make the subject"
       );
@@ -138,12 +156,7 @@ export const HandleRegistrySemantics = SemanticType<HandleRegistryDescription>(
         );
       }
     },
-  },
-  unaryHandleRegistration: {
-    what: "Plugin registration is unary, handles will not be called multiple times as a result of multiple registration",
-    why: "Prevents bugs from multiple registration",
-    law: "For a plugin P, and handle H, calling registerHandles(P) twice will result in H of P being called exactly once only",
-    async check(makeSubject) {
+    async unaryHandleRegistration(makeSubject) {
       const description = (await makeSubject()).expect(
         "Should be able to make the subject"
       );
@@ -190,12 +203,7 @@ export const HandleRegistrySemantics = SemanticType<HandleRegistryDescription>(
         throw new TypeError("Plugin handle should have been called once");
       }
     },
-  },
-  disposable: {
-    what: "HandleRegistry un-registers all plugins on disposal",
-    why: "Prevents resource leaks from HandleRegistry instances",
-    law: "For plugin P and handle H, after disposing the HandleRegistry, H will no longer be called on P",
-    async check(makeSubject) {
+    async disposable(makeSubject) {
       const description = (await makeSubject()).expect(
         "Should be able to make the subject"
       );
@@ -248,5 +256,4 @@ export const HandleRegistrySemantics = SemanticType<HandleRegistryDescription>(
         );
       }
     },
-  },
-});
+  });

--- a/packages/matrix-protection-suite/src/Protection/HandleRegistry/HandleRegistryDescription.ts
+++ b/packages/matrix-protection-suite/src/Protection/HandleRegistry/HandleRegistryDescription.ts
@@ -37,12 +37,23 @@ export interface HandleRegistryDescription<
 }
 
 export const HandleRegistryDescriptionSemantics =
-  SemanticType<HandleRegistryDescription>("HandleRegistryDescription").Law({
-    descriptionBuilding: {
-      what: "When a handle is registered and a new registry is returned, the original registry is not modified.",
-      why: "Keeps the builder pattern clean and prevents bugs in downstream consumers",
-      law: "For empty RegistryDescription R and HandleDescription H, calling R.registerHandleDescription(H) => R' results in R.handleDescriptions = [] and R'.handleDescriptions = [H]",
-      async check(makeSubject) {
+  SemanticType<HandleRegistryDescription>("HandleRegistryDescription")
+    .declare({
+      descriptionBuilding: {
+        what: "When a handle is registered and a new registry is returned, the original registry is not modified.",
+        why: "Keeps the builder pattern clean and prevents bugs in downstream consumers",
+        when: "When registerHandleDescription returns a new HandleRegistryDescription",
+        law: "For empty RegistryDescription R and HandleDescription H, calling R.registerHandleDescription(H) => R' results in R.handleDescriptions = [] and R'.handleDescriptions = [H]",
+      },
+      registryFactory: {
+        what: "A HandleRegistryDescription can produce HandleRegistry instances for a given context.",
+        why: "Keeps the HandleRegistry abstraction clean by binding the context in construction rather than later on",
+        when: "When registryForContext is called with a lifetime and context",
+        law: "For RegistryDescription R with handle union H, calling R.registryForContext(L, C) produces a HandleRegistry<R,C>",
+      },
+    })
+    .verify({
+      async descriptionBuilding(makeSubject) {
         const registry = (await makeSubject()).expect(
           "Should be able to make the subject"
         );
@@ -56,12 +67,7 @@ export const HandleRegistryDescriptionSemantics =
         expect(newRegistry.handleDescriptions).toHaveLength(1);
         expect(newRegistry.handleDescriptions[0]).toBe(handle);
       },
-    },
-    registryFactory: {
-      what: "A HandleRegistryDescription can produce HandleRegistry instances for a given context.",
-      why: "Keeps the HandleRegistry abstraction clean by binding the context in construction rather than later on",
-      law: "For RegistryDescription R with handle union H, calling R.registryForContext(L, C) produces a HandleRegistry<R,C>",
-      async check(makeSubject) {
+      async registryFactory(makeSubject) {
         let establishCount = 0;
         const contextHandle = {
           handleName: "handle",
@@ -84,5 +90,4 @@ export const HandleRegistryDescriptionSemantics =
           .expect("Should be able to construct a registry for the context");
         expect(establishCount).toBe(1);
       },
-    },
-  });
+    });


### PR DESCRIPTION
It is a pain in the ass to write the checks but the information itself is still valuable when refactoring. So I'd rather we still encourage people to write this shit down even if they don't write the checks.

Closes https://github.com/the-draupnir-project/planning/issues/132