### PR TITLE
Fix Policy Notification Protection only inviting joined users

### DIFF
--- a/.changeset/lemon-things-tap.md
+++ b/.changeset/lemon-things-tap.md
@@ -1,0 +1,6 @@
+---
+"draupnir": patch
+---
+
+Fix Policy Notification Room invites only being issued to users with join
+membership.

--- a/apps/draupnir/src/protections/NotificationRoom/NotificationRoom.ts
+++ b/apps/draupnir/src/protections/NotificationRoom/NotificationRoom.ts
@@ -58,7 +58,10 @@ export class NotificationRoomCreator<
     const revision = membershipRevisionIssuer.ok.currentRevision;
     return Ok(
       [...revision.members()]
-        .filter((member) => member.membership === "join")
+        .filter(
+          (member) =>
+            member.membership === "join" || member.membership === "invite"
+        )
         .map((member) => member.userID)
         .filter((userID) => userID !== draupnirUserID)
     );


### PR DESCRIPTION
Fixes: #1113 