### PR TITLE
Add Distribution information to status and version command.

### DIFF
--- a/.changeset/proud-maps-reply.md
+++ b/.changeset/proud-maps-reply.md
@@ -1,0 +1,5 @@
+---
+"draupnir": patch
+---
+
+Add Distrubution information to version information in status / version command.

--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,8 @@ version.txt.tmp
 version.txt
 # branch file generated from npm build
 branch.txt
+# distribution file generated from npm build
+distribution.txt
 
 # Logs
 logs

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,10 @@
 
 # syntax=docker/dockerfile:1.7
 
+# Build-time distribution identifier (default for docker builds). Declared
+# before any FROM so it can be overridden with `--build-arg`.
+ARG DRAUPNIR_DISTRIBUTION=Docker
+
 FROM node:24-slim AS build-stage
 RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
     apt-get update \
@@ -27,6 +31,10 @@ RUN --mount=type=cache,target=/root/.npm npm ci
 COPY . .
 
 # build and install
+# make the build see the distribution value
+ARG DRAUPNIR_DISTRIBUTION
+ENV DRAUPNIR_DISTRIBUTION=${DRAUPNIR_DISTRIBUTION}
+
 RUN npm run build \
     && npm prune --production
 

--- a/apps/draupnir/package.json
+++ b/apps/draupnir/package.json
@@ -9,9 +9,10 @@
   "private": true,
   "scripts": {
     "build": "tsc --project test/tsconfig.json && npm run build:assets",
-    "build:assets": "npm run describe-version && npm run describe-branch",
+    "build:assets": "npm run describe-version && npm run describe-branch && npm run describe-distribution",
     "describe-version": "(git describe > version.txt.tmp && mv version.txt.tmp version.txt) || true && rm -f version.txt.tmp",
     "describe-branch": "(git rev-parse --abbrev-ref HEAD > branch.txt.tmp && mv branch.txt.tmp branch.txt) || true && rm -f branch.txt.tmp",
+    "describe-distribution": "echo \"${DRAUPNIR_DISTRIBUTION:-source}\" > distribution.txt.tmp && mv distribution.txt.tmp distribution.txt",
     "harness-registration": "node dist/appservice/cli.js -r -u \"http://host.docker.internal:9000\" --enable-source-maps",
     "test:unit": "mocha --require './test/tsnode.cjs' --forbid-only 'test/unit/**/*.{ts,tsx}'",
     "test:unit:single": "mocha --require test/tsnode.cjs",

--- a/apps/draupnir/src/appservice/bot/VersionCommand.tsx
+++ b/apps/draupnir/src/appservice/bot/VersionCommand.tsx
@@ -9,7 +9,7 @@ import {
   describeCommand,
 } from "@the-draupnir-project/interface-manager";
 import { AppserviceBotInterfaceAdaptor } from "./AppserviceBotInterfaceAdaptor";
-import { CURRENT_BRANCH, SOFTWARE_VERSION, DISTRIBUTION} from "../../config";
+import { CURRENT_BRANCH, SOFTWARE_VERSION, DISTRIBUTION } from "../../config";
 
 type AppserviceVersionInfo = {
   version: string;

--- a/apps/draupnir/src/appservice/bot/VersionCommand.tsx
+++ b/apps/draupnir/src/appservice/bot/VersionCommand.tsx
@@ -9,11 +9,12 @@ import {
   describeCommand,
 } from "@the-draupnir-project/interface-manager";
 import { AppserviceBotInterfaceAdaptor } from "./AppserviceBotInterfaceAdaptor";
-import { CURRENT_BRANCH, SOFTWARE_VERSION } from "../../config";
+import { CURRENT_BRANCH, SOFTWARE_VERSION, DISTRIBUTION} from "../../config";
 
 type AppserviceVersionInfo = {
   version: string;
   branch: string;
+  distribution: string;
 };
 
 export const AppserviceVersionCommand = describeCommand({
@@ -26,6 +27,7 @@ export const AppserviceVersionCommand = describeCommand({
     return Ok({
       version: SOFTWARE_VERSION,
       branch: CURRENT_BRANCH,
+      distribution: DISTRIBUTION,
     });
   },
 });
@@ -42,6 +44,9 @@ AppserviceBotInterfaceAdaptor.describeRenderer(AppserviceVersionCommand, {
         <br />
         <b>Branch: </b>
         <code>{result.ok.branch}</code>
+        <br />
+        <b>Distribution: </b>
+        <code>{result.ok.distribution}</code>
       </root>
     );
   },

--- a/apps/draupnir/src/commands/StatusCommand.tsx
+++ b/apps/draupnir/src/commands/StatusCommand.tsx
@@ -13,6 +13,7 @@ import {
   DOCUMENTATION_URL,
   PACKAGE_JSON,
   SOFTWARE_VERSION,
+  DISTRIBUTION,
 } from "../config";
 import {
   ActionResult,
@@ -59,6 +60,7 @@ export type StatusInfo = {
   branch: string;
   repository: string;
   documentationURL: string;
+  distribution: string;
 } & DraupnirNotificationRoomsInfo &
   WatchedPolicyRoomsInfo;
 
@@ -142,6 +144,7 @@ export function draupnirStatusInfo(draupnir: Draupnir): StatusInfo {
     documentationURL: DOCUMENTATION_URL,
     version: SOFTWARE_VERSION,
     branch: CURRENT_BRANCH,
+    distribution: DISTRIBUTION,
     repository: (PACKAGE_JSON["repository"] as string | undefined) ?? "Unknown",
     ...extractProtectionNotificationRooms(draupnir),
   };
@@ -234,6 +237,9 @@ export function renderStatusInfo(info: StatusInfo): DocumentNode {
       <br />
       <b>Branch: </b>
       <code>{info.branch}</code>
+      <br />
+      <b>Distribution: </b>
+      <code>{info.distribution}</code>
       <br />
       <b>Repository: </b>
       <code>{info.repository}</code>

--- a/apps/draupnir/src/config.ts
+++ b/apps/draupnir/src/config.ts
@@ -503,6 +503,24 @@ export const CURRENT_BRANCH = (() => {
   return /^(.*)$/m.exec(branchFile)?.at(0) ?? defaultText;
 })();
 
+export const DISTRIBUTION = (() => {
+  let distributionFile;
+  const defaultText =
+    "A distribution name was either not provided when building Draupnir or could not be read.";
+  try {
+    distributionFile = fs.readFileSync(
+      path.join(__dirname, "../distribution.txt"),
+      "utf-8"
+    );
+  } catch (e) {
+    LogService.error("config", "Could not read Draupnir distribution", e);
+    distributionFile = defaultText;
+  }
+  // it's important to ignore the newline if the distribution is going to be put
+  // into <pre> or <code> where it will create an unnecessary newline.
+  return /^(.*)$/m.exec(distributionFile)?.at(0) ?? defaultText;
+})();
+
 export const DOCUMENTATION_URL =
   "https://the-draupnir-project.github.io/draupnir-documentation/";
 

--- a/apps/draupnir/test/appservice/integration/versionAndBranchDraupnirTest.ts
+++ b/apps/draupnir/test/appservice/integration/versionAndBranchDraupnirTest.ts
@@ -39,5 +39,6 @@ describe("Test appservice version command", function () {
     }
     expect(result.ok).toHaveProperty("version");
     expect(result.ok).toHaveProperty("branch");
+    expect(result.ok).toHaveProperty("distribution");
   });
 });


### PR DESCRIPTION
This came up today in a discussion about the various ways Draupnir can be installed and distributed that its probably useful to have this little mechanism to define where your Draupnir build originated.

This is essentially Cat CTRL-C/V on the branch metadata.