### PR TITLE
Pin our CI to Sha Digests instead of moving version tags and add Renovate maintenance for this.

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -18,6 +18,7 @@
     {
       matchManagers: ["github-actions"],
       pinDigests: true,
+      minimumReleaseAge: "7 days",
       automerge: false,
       platformAutomerge: false,
       matchUpdateTypes: ["minor", "patch", "pin", "digest", "pinDigest"],

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,6 +1,26 @@
 // SPDX-FileCopyrightText: 2024 Aminda Suomalainen <suomalainen@aminda.eu>
+// SPDX-FileCopyrightText: 2026 Catalan Lover <catalanlover@protonmail.com>
 //
-// SPDX-License-Identifier: CC0-1.0
+// SPDX-License-Identifier: Apache-2.0
+//
+// Automerges are false because we need to wait until we have seen this actually attempt to run before we approve it.
+// Automerges would anyways only be enabled for minor updates to workflows.
+//
 {
   extends: ["github>the-draupnir-project/.github:renovate-shared"],
+  enabledManagers: ["github-actions"],
+  packageRules: [
+    {
+      matchManagers: ["github-actions"],
+      matchUpdateTypes: ["major"],
+      automerge: false,
+    },
+    {
+      matchManagers: ["github-actions"],
+      pinDigests: true,
+      automerge: false,
+      platformAutomerge: false,
+      matchUpdateTypes: ["minor", "patch", "pin", "digest", "pinDigest"],
+    },
+  ],
 }

--- a/.github/workflows/docker-hub-develop.yml
+++ b/.github/workflows/docker-hub-develop.yml
@@ -29,29 +29,29 @@ jobs:
       artifact-metadata: write
     steps:
       - name: Check out
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
           fetch-depth: 0
           fetch-tags: true
 
       # Needed for multi platform builds
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v4
+        uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a
         with:
           platforms: ${{ env.PLATFORMS }}
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd
 
       - name: Log in to Docker Hub
-        uses: docker/login-action@v4
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Build image
         id: push
-        uses: docker/build-push-action@v7
+        uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f
         with:
           context: .
           file: ./Dockerfile
@@ -77,7 +77,7 @@ jobs:
       - name: Attest pushed image
         id: attest
         if: ${{ env.PUSH == 'true' }}
-        uses: actions/attest@v4
+        uses: actions/attest@59d89421af93a897026c735860bf21b6eb4f7b26
         with:
           subject-name: docker.io/${{ env.DOCKER_NAMESPACE }}/draupnir
           subject-digest: ${{ steps.push.outputs.digest }}

--- a/.github/workflows/docker-hub-latest.yml
+++ b/.github/workflows/docker-hub-latest.yml
@@ -27,7 +27,7 @@ jobs:
       artifact-metadata: write
     steps:
       - name: Check out
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
           fetch-depth: 0
           fetch-tags: true
@@ -37,22 +37,22 @@ jobs:
 
       # Needed for multi platform builds
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v4
+        uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a
         with:
           platforms: ${{ env.PLATFORMS }}
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd
 
       - name: Log in to Docker Hub
-        uses: docker/login-action@v4
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Build image
         id: push
-        uses: docker/build-push-action@v7
+        uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f
         with:
           context: .
           file: ./Dockerfile
@@ -76,7 +76,7 @@ jobs:
 
       - name: Attest pushed image
         id: attest
-        uses: actions/attest@v4
+        uses: actions/attest@59d89421af93a897026c735860bf21b6eb4f7b26
         with:
           subject-name: docker.io/${{ env.DOCKER_NAMESPACE }}/draupnir
           subject-digest: ${{ steps.push.outputs.digest }}

--- a/.github/workflows/docker-hub-release.yml
+++ b/.github/workflows/docker-hub-release.yml
@@ -27,7 +27,7 @@ jobs:
       artifact-metadata: write
     steps:
       - name: Check out
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
           fetch-depth: 0
           fetch-tags: true
@@ -38,22 +38,22 @@ jobs:
 
       # Needed for multi platform builds
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v4
+        uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a
         with:
           platforms: ${{ env.PLATFORMS }}
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd
 
       - name: Log in to Docker Hub
-        uses: docker/login-action@v4
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Build image
         id: push
-        uses: docker/build-push-action@v7
+        uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f
         with:
           context: .
           file: ./Dockerfile
@@ -77,7 +77,7 @@ jobs:
 
       - name: Attest pushed image
         id: attest
-        uses: actions/attest@v4
+        uses: actions/attest@59d89421af93a897026c735860bf21b6eb4f7b26
         with:
           subject-name: docker.io/${{ env.DOCKER_NAMESPACE }}/draupnir
           subject-digest: ${{ steps.push.outputs.digest }}

--- a/.github/workflows/ghcr-all-dev-branches.yml
+++ b/.github/workflows/ghcr-all-dev-branches.yml
@@ -31,7 +31,7 @@ jobs:
       attestations: write
     steps:
       - name: Check out
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
           fetch-depth: 0
           fetch-tags: true
@@ -43,15 +43,15 @@ jobs:
 
       # Needed for multi platform builds
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v4
+        uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a
         with:
           platforms: ${{ env.PLATFORMS }}
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd
 
       - name: Log in to GHCR
-        uses: docker/login-action@v4
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -59,7 +59,7 @@ jobs:
 
       - name: Derive image tags
         id: meta
-        uses: docker/metadata-action@v6
+        uses: docker/metadata-action@030e881283bb7a6894de51c315a6bfe6a94e05cf
         with:
           images:
             ghcr.io/${{ steps.image_owner.outputs.image_owner }}/${{
@@ -70,7 +70,7 @@ jobs:
 
       - name: Build image
         id: push
-        uses: docker/build-push-action@v7
+        uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f
         with:
           context: .
           file: ./Dockerfile

--- a/.github/workflows/ghcr-latest.yml
+++ b/.github/workflows/ghcr-latest.yml
@@ -23,7 +23,7 @@ jobs:
       artifact-metadata: write
     steps:
       - name: Check out
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
           fetch-depth: 0
           fetch-tags: true
@@ -37,15 +37,15 @@ jobs:
 
       # Needed for multi platform builds
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v4
+        uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a
         with:
           platforms: ${{ env.PLATFORMS }}
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd
 
       - name: Log in to GHCR
-        uses: docker/login-action@v4
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -53,7 +53,7 @@ jobs:
 
       - name: Build and push image to GHCR
         id: push_ghcr
-        uses: docker/build-push-action@v7
+        uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f
         with:
           context: .
           file: ./Dockerfile
@@ -77,7 +77,7 @@ jobs:
 
       - name: Attest pushed image
         id: attest
-        uses: actions/attest@v4
+        uses: actions/attest@59d89421af93a897026c735860bf21b6eb4f7b26
         with:
           subject-name:
             ghcr.io/${{ steps.image_owner.outputs.image_owner }}/draupnir

--- a/.github/workflows/ghcr-release.yml
+++ b/.github/workflows/ghcr-release.yml
@@ -23,7 +23,7 @@ jobs:
       artifact-metadata: write
     steps:
       - name: Check out
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
           fetch-depth: 0
           fetch-tags: true
@@ -38,15 +38,15 @@ jobs:
 
       # Needed for multi platform builds
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v4
+        uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a
         with:
           platforms: ${{ env.PLATFORMS }}
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd
 
       - name: Log in to GHCR
-        uses: docker/login-action@v4
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -54,7 +54,7 @@ jobs:
 
       - name: Build and push image to GHCR
         id: push_ghcr
-        uses: docker/build-push-action@v7
+        uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f
         with:
           context: .
           file: ./Dockerfile
@@ -78,7 +78,7 @@ jobs:
 
       - name: Attest pushed image
         id: attest
-        uses: actions/attest@v4
+        uses: actions/attest@59d89421af93a897026c735860bf21b6eb4f7b26
         with:
           subject-name:
             ghcr.io/${{ steps.image_owner.outputs.image_owner }}/draupnir

--- a/.github/workflows/mjolnir.yml
+++ b/.github/workflows/mjolnir.yml
@@ -19,10 +19,10 @@ jobs:
     name: Build & Lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
 
       - name: Specifically use node 24 like in the readme.
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
         with:
           node-version: "24"
           cache: "npm"
@@ -35,9 +35,9 @@ jobs:
     name: Unit tests
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
       - name: Specifically use node 24 like in the readme.
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
         with:
           node-version: "24"
           cache: "npm"
@@ -50,8 +50,8 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 60
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-node@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
         with:
           node-version: "24"
           cache: "npm"
@@ -74,8 +74,8 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-node@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
         with:
           node-version: "24"
           cache: "npm"

--- a/.github/workflows/sign-off.yml
+++ b/.github/workflows/sign-off.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check PR for sign-off text
-        uses: actions/github-script@v9
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3
         with:
           script: |
             // We don't require owners or members of the org to sign off.

--- a/.github/workflows/workflow-gate.yml
+++ b/.github/workflows/workflow-gate.yml
@@ -1,0 +1,73 @@
+# SPDX-FileCopyrightText: 2026 Catalan Lover <catalanlover@protonmail.com>
+#
+# SPDX-License-Identifier: Apache-2.0
+
+name: Workflow Gate
+
+on:
+  workflow_run:
+    workflows:
+      - "GHCR - Development Branches"
+      - "Docker Hub - Release"
+      - "Docker Hub - Latest"
+      - "Docker Hub - Develop"
+      - "GHCR - Release"
+      - "Tests"
+      - "GHCR - Latest"
+      - "Contribution requirements"
+    types: [completed]
+
+permissions:
+  checks: write
+
+jobs:
+  gate:
+    runs-on: ubuntu-latest
+    if:
+      github.event.workflow_run.event == 'pull_request' ||
+      startsWith(github.event.workflow_run.head_branch, 'develop')
+    steps:
+      - name: Aggregate workflow status
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3
+        with:
+          script: |
+            const sha = context.payload.workflow_run.head_commit.id;
+
+            // Get all check runs for this commit
+            const checks = await github.rest.checks.listForRef({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              ref: sha,
+            });
+
+            // Filter out the gate itself and third-party checks
+            const knownWorkflows = [
+              'GHCR - Development Branches', 'Docker Hub - Release', 'Docker Hub - Latest', 'Docker Hub - Develop',
+              'GHCR - Release', 'Tests', 'GHCR - Latest', 'Contribution requirements'
+            ];
+            const relevantChecks = checks.data.filter(check => knownWorkflows.includes(check.name));
+
+            // Check if ANY workflow is still running or queued
+            const incompleteChecks = relevantChecks.filter(check => check.status !== 'completed');
+            if (incompleteChecks.length > 0) {
+              console.log(`Waiting on ${incompleteChecks.length} checks... exiting for now.`);
+              return;
+            }
+
+            // Exclude skipped from failing the gate, treat success/neutral/skipped as OK
+            const allPassed = relevantChecks.every(check =>
+              ['success', 'neutral', 'skipped'].includes(check.conclusion)
+            );
+
+            await github.rest.checks.create({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              name: 'Workflow Gate',
+              head_sha: sha,
+              status: 'completed',
+              conclusion: allPassed ? 'success' : 'failure',
+              output: {
+                title: 'Workflow Status',
+                summary: `${relevantChecks.length} workflow(s) evaluated: ${allPassed ? '✅ all passed' : '❌ some failed'}`,
+              },
+            });


### PR DESCRIPTION
This work pins all our CI to sha digests like modern security practices recommends and then adds renovate maintenance for this.

The new workflow added by this PR is to allow the branch protection rule that makes automerges work well work because our CIs dont spit out approvals that get picked up by Branch Protection status checks.