### PR TITLE
Perfect Attestation work and cleanup missing GHCR Attestation

### DIFF
--- a/.github/workflows/docker-hub-develop.yml
+++ b/.github/workflows/docker-hub-develop.yml
@@ -71,6 +71,7 @@ jobs:
           # prettier-ignore
           outputs: type=image,name=target,annotation-index.org.opencontainers.image.description=Drapunir is a community management platform for Matrix.
           sbom: true
+          provenance: true
           tags: |
             ${{ env.DOCKER_NAMESPACE }}/draupnir:develop
 

--- a/.github/workflows/docker-hub-latest.yml
+++ b/.github/workflows/docker-hub-latest.yml
@@ -71,6 +71,7 @@ jobs:
           # prettier-ignore
           outputs: type=image,name=target,annotation-index.org.opencontainers.image.description=Drapunir is a community management platform for Matrix.
           sbom: true
+          provenance: true
           tags: |
             ${{ env.DOCKER_NAMESPACE }}/draupnir:latest
 

--- a/.github/workflows/docker-hub-release.yml
+++ b/.github/workflows/docker-hub-release.yml
@@ -72,6 +72,7 @@ jobs:
           # prettier-ignore
           outputs: type=image,name=target,annotation-index.org.opencontainers.image.description=Drapunir is a community management platform for Matrix.
           sbom: true
+          provenance: true
           tags: |
             ${{ env.DOCKER_NAMESPACE }}/draupnir:${{ steps.release_version.outputs.release_version }}
 

--- a/.github/workflows/ghcr-all-dev-branches.yml
+++ b/.github/workflows/ghcr-all-dev-branches.yml
@@ -29,6 +29,7 @@ jobs:
       packages: write
       contents: read
       attestations: write
+      artifact-metadata: write
     steps:
       - name: Check out
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd

--- a/.github/workflows/ghcr-all-dev-branches.yml
+++ b/.github/workflows/ghcr-all-dev-branches.yml
@@ -90,4 +90,13 @@ jobs:
           # prettier-ignore
           outputs: type=image,name=target,annotation-index.org.opencontainers.image.description=Drapunir is a community management platform for Matrix.
           sbom: true
+          provenance: true
           tags: ${{ steps.meta.outputs.tags }}
+
+      - name: Attest pushed image
+        uses: actions/attest@59d89421af93a897026c735860bf21b6eb4f7b26
+        with:
+          # prettier-ignore
+          subject-name: ghcr.io/${{ steps.image_owner.outputs.image_owner }}/${{ env.IMAGE_NAME }}
+          subject-digest: ${{ steps.push.outputs.digest }}
+          push-to-registry: true


### PR DESCRIPTION
So the story here is quite simple. GHCR used to have its own Production publish image workflow that had attestation.

That part kinda did not survive when we moved on to Unify. He he so Thats fixed now and oh ye we also provide better providence.

Like we now provide both SBOM like before but also SLSA providence. The TLDR on this one is that SBOM is your BOM and SLSA talks about shit like how it was built. Both are important for the goal of all this attestation work tbh.

Like ofc Perfect Reproducibility would also be nice but thats a future goal and tbh.

Final successful attestation https://github.com/the-draupnir-project/Draupnir/attestations/27831236
SLSA Providence Attestation Docs: https://slsa.dev/spec/v1.0/provenance
SBOM Attestation Documentation by Docker: https://docs.docker.com/build/metadata/attestations/sbom/