### PR TITLE
Make Docker Jobs skip outside the main repository due to fork incompat

### DIFF
--- a/.github/workflows/docker-hub-develop.yml
+++ b/.github/workflows/docker-hub-develop.yml
@@ -22,6 +22,7 @@ env:
 jobs:
   docker-latest:
     runs-on: ubuntu-latest
+    if: ${{ github.repository == 'the-draupnir-project/Draupnir' }}
     permissions:
       id-token: write
       contents: read

--- a/.github/workflows/docker-hub-latest.yml
+++ b/.github/workflows/docker-hub-latest.yml
@@ -20,6 +20,7 @@ env:
 jobs:
   docker-release:
     runs-on: ubuntu-latest
+    if: ${{ github.repository == 'the-draupnir-project/Draupnir' }}
     permissions:
       id-token: write
       contents: read

--- a/.github/workflows/docker-hub-release.yml
+++ b/.github/workflows/docker-hub-release.yml
@@ -20,6 +20,7 @@ env:
 jobs:
   docker-release:
     runs-on: ubuntu-latest
+    if: ${{ github.repository == 'the-draupnir-project/Draupnir' }}
     permissions:
       id-token: write
       contents: read


### PR DESCRIPTION
While working on some shit outside of the main repo Cat realised oh ye our docker hub workflows try to run outside this repo but they wont ever work due to hard coded Gnuxie namespaces and Cat CBA making them dynamic today so Cat made this quick fix instead.