### PR TITLE
Update @types/node to 24.12.4 and @sinclair/typebox to 0.34.49

### DIFF
--- a/apps/draupnir/package.json
+++ b/apps/draupnir/package.json
@@ -31,7 +31,7 @@
     "@types/jsdom": "21.1.7",
     "@types/mocha": "^10.0.7",
     "@types/nedb": "^1.8.16",
-    "@types/node": "^24.12.0",
+    "@types/node": "^24.12.4",
     "@types/pg": "^8.6.5",
     "@types/request": "^2.48.12",
     "crypto-js": "^4.2.0",
@@ -43,7 +43,7 @@
   "dependencies": {
     "@gnuxie/typescript-result": "^1.0.0",
     "@sentry/node": "^7.17.2",
-    "@sinclair/typebox": "0.34.13",
+    "@sinclair/typebox": "0.34.49",
     "@the-draupnir-project/interface-manager": "4.2.6",
     "@the-draupnir-project/matrix-basic-types": "1.5.1",
     "@the-draupnir-project/mps-interface-adaptor": "0.6.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -33,7 +33,7 @@
       "dependencies": {
         "@gnuxie/typescript-result": "^1.0.0",
         "@sentry/node": "^7.17.2",
-        "@sinclair/typebox": "0.34.13",
+        "@sinclair/typebox": "0.34.49",
         "@the-draupnir-project/interface-manager": "4.2.6",
         "@the-draupnir-project/matrix-basic-types": "1.5.1",
         "@the-draupnir-project/mps-interface-adaptor": "0.6.0",
@@ -61,7 +61,7 @@
         "@types/jsdom": "21.1.7",
         "@types/mocha": "^10.0.7",
         "@types/nedb": "^1.8.16",
-        "@types/node": "^24.12.0",
+        "@types/node": "^24.12.4",
         "@types/pg": "^8.6.5",
         "@types/request": "^2.48.12",
         "crypto-js": "^4.2.0",
@@ -88,9 +88,9 @@
       }
     },
     "apps/draupnir/node_modules/@types/node": {
-      "version": "24.12.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.12.0.tgz",
-      "integrity": "sha512-GYDxsZi3ChgmckRT9HPU0WEhKLP08ev/Yfcq2AstjrDASOYCSXeyjDsHg4v5t4jOj7cyDX3vmprafKlWIG9MXQ==",
+      "version": "24.12.4",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.12.4.tgz",
+      "integrity": "sha512-GUUEShf+PBCGW2KaXwcIt3Yk+e3pkKwWKb9GSyM9WQVE+ep2jzmHdGsHzu4wgcZy5fN9FBdVzjpBQsYlpfpgLA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3416,9 +3416,9 @@
       "license": "MIT"
     },
     "node_modules/@sinclair/typebox": {
-      "version": "0.34.13",
-      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.34.13.tgz",
-      "integrity": "sha512-ceVKqyCEgC355Kw0s/0tyfY9MzMQINSykJ/pG2w6YnaZyrcjV48svZpr8lVZrYgWjzOmrIPBhQRAtr/7eJpA5g==",
+      "version": "0.34.49",
+      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.34.49.tgz",
+      "integrity": "sha512-brySQQs7Jtn0joV8Xh9ZV/hZb9Ozb0pmazDIASBkYKCjXrXU3mpcFahmK/z4YDhGkQvP9mWJbVyahdtU5wQA+A==",
       "license": "MIT"
     },
     "node_modules/@sinonjs/commons": {
@@ -3954,12 +3954,12 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "25.3.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.3.0.tgz",
-      "integrity": "sha512-4K3bqJpXpqfg2XKGK9bpDTc6xO/xoUP/RBWS7AtRMug6zZFaRekiLzjVtAoZMquxoAbzBvy5nxQ7veS5eYzf8A==",
+      "version": "25.9.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.9.1.tgz",
+      "integrity": "sha512-xfrlY7UD5rMJk3ZVJP8BNzS28J36YJg+xp+LPXV1TdWxr8uMH5A860QNxYDGQe/ylDSgjxE52Q9VnO7p75tJxg==",
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~7.18.0"
+        "undici-types": ">=7.24.0 <7.24.7"
       }
     },
     "node_modules/@types/pg": {
@@ -13879,9 +13879,9 @@
       "peer": true
     },
     "node_modules/undici-types": {
-      "version": "7.18.2",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
-      "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
+      "version": "7.24.6",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.24.6.tgz",
+      "integrity": "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==",
       "license": "MIT"
     },
     "node_modules/unist-util-is": {
@@ -14606,13 +14606,13 @@
       },
       "devDependencies": {
         "@types/glob-to-regexp": "^0.4.4",
-        "@types/node": "^24.12.0"
+        "@types/node": "^24.12.4"
       }
     },
     "packages/matrix-basic-types/node_modules/@types/node": {
-      "version": "24.12.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.12.0.tgz",
-      "integrity": "sha512-GYDxsZi3ChgmckRT9HPU0WEhKLP08ev/Yfcq2AstjrDASOYCSXeyjDsHg4v5t4jOj7cyDX3vmprafKlWIG9MXQ==",
+      "version": "24.12.4",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.12.4.tgz",
+      "integrity": "sha512-GUUEShf+PBCGW2KaXwcIt3Yk+e3pkKwWKb9GSyM9WQVE+ep2jzmHdGsHzu4wgcZy5fN9FBdVzjpBQsYlpfpgLA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -14641,12 +14641,12 @@
       "devDependencies": {
         "@types/crypto-js": "^4.2.2",
         "@types/glob-to-regexp": "^0.4.4",
-        "@types/node": "^24.12.0",
+        "@types/node": "^24.12.4",
         "typedoc": "^0.28.16",
         "wait-for-expect": "^3.0.2"
       },
       "peerDependencies": {
-        "@sinclair/typebox": "0.34.13",
+        "@sinclair/typebox": "0.34.49",
         "@the-draupnir-project/matrix-basic-types": "^1.5.1"
       }
     },
@@ -14661,22 +14661,22 @@
       "devDependencies": {
         "@types/crypto-js": "^4.1.2",
         "@types/glob-to-regexp": "^0.4.1",
-        "@types/node": "^24.12.0",
+        "@types/node": "^24.12.4",
         "@vector-im/matrix-bot-sdk": "0.8.0-element.3",
         "matrix-protection-suite": "npm:@the-draupnir-project/matrix-protection-suite@7.1.0",
         "typedoc": "^0.26.3"
       },
       "peerDependencies": {
-        "@sinclair/typebox": "0.34.13",
+        "@sinclair/typebox": "0.34.49",
         "@the-draupnir-project/matrix-basic-types": "1.5.1",
         "@vector-im/matrix-bot-sdk": "^0.8.0-element.3",
         "matrix-protection-suite": "npm:@the-draupnir-project/matrix-protection-suite@7.1.0"
       }
     },
     "packages/matrix-protection-suite-for-matrix-bot-sdk/node_modules/@types/node": {
-      "version": "24.12.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.12.0.tgz",
-      "integrity": "sha512-GYDxsZi3ChgmckRT9HPU0WEhKLP08ev/Yfcq2AstjrDASOYCSXeyjDsHg4v5t4jOj7cyDX3vmprafKlWIG9MXQ==",
+      "version": "24.12.4",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.12.4.tgz",
+      "integrity": "sha512-GUUEShf+PBCGW2KaXwcIt3Yk+e3pkKwWKb9GSyM9WQVE+ep2jzmHdGsHzu4wgcZy5fN9FBdVzjpBQsYlpfpgLA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -14768,9 +14768,9 @@
       "license": "MIT"
     },
     "packages/matrix-protection-suite/node_modules/@types/node": {
-      "version": "24.12.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.12.0.tgz",
-      "integrity": "sha512-GYDxsZi3ChgmckRT9HPU0WEhKLP08ev/Yfcq2AstjrDASOYCSXeyjDsHg4v5t4jOj7cyDX3vmprafKlWIG9MXQ==",
+      "version": "24.12.4",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.12.4.tgz",
+      "integrity": "sha512-GUUEShf+PBCGW2KaXwcIt3Yk+e3pkKwWKb9GSyM9WQVE+ep2jzmHdGsHzu4wgcZy5fN9FBdVzjpBQsYlpfpgLA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -14789,20 +14789,20 @@
       "version": "0.6.0",
       "license": "Apache-2.0",
       "devDependencies": {
-        "@types/node": "^24.12.0",
+        "@types/node": "^24.12.4",
         "matrix-protection-suite": "npm:@the-draupnir-project/matrix-protection-suite@7.1.0"
       },
       "peerDependencies": {
         "@gnuxie/typescript-result": "^1.0.0",
-        "@sinclair/typebox": "^0.34.13",
+        "@sinclair/typebox": "^0.34.49",
         "@the-draupnir-project/interface-manager": "^4.2.3",
         "matrix-protection-suite": "npm:@the-draupnir-project/matrix-protection-suite@7.1.0"
       }
     },
     "packages/mps-interface-adaptor/node_modules/@types/node": {
-      "version": "24.12.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.12.0.tgz",
-      "integrity": "sha512-GYDxsZi3ChgmckRT9HPU0WEhKLP08ev/Yfcq2AstjrDASOYCSXeyjDsHg4v5t4jOj7cyDX3vmprafKlWIG9MXQ==",
+      "version": "24.12.4",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.12.4.tgz",
+      "integrity": "sha512-GUUEShf+PBCGW2KaXwcIt3Yk+e3pkKwWKb9GSyM9WQVE+ep2jzmHdGsHzu4wgcZy5fN9FBdVzjpBQsYlpfpgLA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/packages/matrix-basic-types/package.json
+++ b/packages/matrix-basic-types/package.json
@@ -23,7 +23,7 @@
   },
   "devDependencies": {
     "@types/glob-to-regexp": "^0.4.4",
-    "@types/node": "^24.12.0"
+    "@types/node": "^24.12.4"
   },
   "dependencies": {
     "@gnuxie/typescript-result": "^1.0.0",

--- a/packages/matrix-protection-suite-for-matrix-bot-sdk/package.json
+++ b/packages/matrix-protection-suite-for-matrix-bot-sdk/package.json
@@ -24,7 +24,7 @@
   "devDependencies": {
     "@types/crypto-js": "^4.1.2",
     "@types/glob-to-regexp": "^0.4.1",
-    "@types/node": "^24.12.0",
+    "@types/node": "^24.12.4",
     "@vector-im/matrix-bot-sdk": "0.8.0-element.3",
     "matrix-protection-suite": "npm:@the-draupnir-project/matrix-protection-suite@7.1.0",
     "typedoc": "^0.26.3"
@@ -34,7 +34,7 @@
     "await-lock": "^2.2.2"
   },
   "peerDependencies": {
-    "@sinclair/typebox": "0.34.13",
+    "@sinclair/typebox": "0.34.49",
     "@the-draupnir-project/matrix-basic-types": "1.5.1",
     "@vector-im/matrix-bot-sdk": "^0.8.0-element.3",
     "matrix-protection-suite": "npm:@the-draupnir-project/matrix-protection-suite@7.1.0"

--- a/packages/matrix-protection-suite/package.json
+++ b/packages/matrix-protection-suite/package.json
@@ -26,7 +26,7 @@
   "devDependencies": {
     "@types/crypto-js": "^4.2.2",
     "@types/glob-to-regexp": "^0.4.4",
-    "@types/node": "^24.12.0",
+    "@types/node": "^24.12.4",
     "typedoc": "^0.28.16",
     "wait-for-expect": "^3.0.2"
   },
@@ -39,7 +39,7 @@
     "ulidx": "^2.3.0"
   },
   "peerDependencies": {
-    "@sinclair/typebox": "0.34.13",
+    "@sinclair/typebox": "0.34.49",
     "@the-draupnir-project/matrix-basic-types": "^1.5.1"
   },
   "publishConfig": {

--- a/packages/mps-interface-adaptor/package.json
+++ b/packages/mps-interface-adaptor/package.json
@@ -22,12 +22,12 @@
   },
   "private": false,
   "devDependencies": {
-    "@types/node": "^24.12.0",
+    "@types/node": "^24.12.4",
     "matrix-protection-suite": "npm:@the-draupnir-project/matrix-protection-suite@7.1.0"
   },
   "peerDependencies": {
     "@gnuxie/typescript-result": "^1.0.0",
-    "@sinclair/typebox": "^0.34.13",
+    "@sinclair/typebox": "^0.34.49",
     "@the-draupnir-project/interface-manager": "^4.2.3",
     "matrix-protection-suite": "npm:@the-draupnir-project/matrix-protection-suite@7.1.0"
   },


### PR DESCRIPTION
Renovate failed to generate this artefact so i had to manually go and do it. Something about our monorepo setup is pissing Renovate off and making it not work. Will have to be investigated further ofc at a later date and probably by Cat and Gnuxie or just Gnuxie as Cat is not a npm expert.