### PR TITLE
Update Renovate Config to hopefully fix Renovate.

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -10,6 +10,27 @@
   extends: ["github>the-draupnir-project/.github:renovate-shared"],
   packageRules: [
     {
+      groupName: "Production Dependencies",
+      matchPackagePatterns: ["*"],
+      matchDepTypes: [
+        "dependencies",
+        "devDependencies",
+        "peerDependencies",
+        "optionalDependencies",
+      ],
+    },
+    {
+      groupName: "Development Dependencies",
+      matchPackagePatterns: ["*"],
+      matchDepTypes: [
+        "pre-commit",
+        "devDependencies",
+        "peerDependencies",
+        "optionalDependencies",
+      ],
+      matchPackageNames: ["!/^@types.*/"],
+    },
+    {
       matchManagers: ["github-actions"],
       matchUpdateTypes: ["major"],
       automerge: false,


### PR DESCRIPTION
Renovate is a bit broken by the fact that we are a monorepo and peer deps Screws Renovate over big time.