### PR TITLE
Improve merge queue CI via Build Validator workflow for all branches*.

### DIFF
--- a/.github/workflows/ghcr-all-dev-branches.yml
+++ b/.github/workflows/ghcr-all-dev-branches.yml
@@ -11,6 +11,7 @@ on:
       - "dependabot/**"
       - "renovate/**"
       - "github-actions/**"
+      - "gh-readonly-queue/**"
 
 concurrency:
   group: ghcr-dev-${{ github.ref }}

--- a/.github/workflows/validate-docker-build.yml
+++ b/.github/workflows/validate-docker-build.yml
@@ -1,0 +1,87 @@
+# SPDX-FileCopyrightText: 2026 Catalan Lover <catalanlover@protonmail.com>
+#
+# SPDX-License-Identifier: Apache-2.0
+# This file is derived from the ghcr-all-dev-branches.yml workflow, but instead of pushing its results, it only validates the Docker build. It also runs on all excluded branches to validate builds on excluded branches.
+
+name: "Validate Docker Build"
+
+# Main is not excluded due to that we want access to validate the build on main and to enable scout mode just like we have for breaking synapse changes.
+on:
+  push:
+    branches-ignore:
+      - "dependabot/**"
+      - "github-actions/**"
+  schedule:
+    - cron: "20 20 * * *"
+  merge_group:
+    branches: [main]
+
+concurrency:
+  group: docker-test-build-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  IMAGE_NAME: draupnir
+  PLATFORMS: linux/amd64,linux/arm64
+  IMG_SOURCE: https://github.com/${{ github.repository }}
+
+jobs:
+  validate-docker-build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Check out
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          fetch-depth: 0
+          fetch-tags: true
+      - name: Set lowercase image owner
+        id: image_owner
+        run:
+          echo "image_owner=$(echo '${{ github.repository_owner }}' | tr
+          '[:upper:]' '[:lower:]')" >> $GITHUB_OUTPUT
+
+      # Needed for multi platform builds
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a
+        with:
+          platforms: ${{ env.PLATFORMS }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd
+
+      - name: Derive image tags
+        id: meta
+        uses: docker/metadata-action@030e881283bb7a6894de51c315a6bfe6a94e05cf
+        with:
+          images:
+            ghcr.io/${{ steps.image_owner.outputs.image_owner }}/${{
+            env.IMAGE_NAME }}
+          tags: |
+            type=ref,event=branch
+            type=sha,prefix=sha-
+
+      - name: Build image
+        id: push
+        uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f
+        with:
+          context: .
+          file: ./Dockerfile
+          platforms: ${{ env.PLATFORMS }}
+          push: false
+          # Shared Buildx cache scope reused by all container image workflows.
+          # Keep the scope name aligned across workflows to maximize cache hits.
+          cache-from: type=gha,scope=draupnir-container-build
+          labels: |
+            org.opencontainers.image.source=${{ env.IMG_SOURCE }}
+            org.opencontainers.image.revision=${{ github.sha }}
+            org.opencontainers.image.version=${{ github.ref_name }}-${{ github.sha }}
+            org.opencontainers.image.ref.name=${{ github.ref_name }}
+            org.opencontainers.image.licenses=Apache-2.0
+
+          # prettier-ignore
+          outputs: type=image,name=target,annotation-index.org.opencontainers.image.description=Draupnir is a community management platform for Matrix.
+          sbom: true
+          provenance: true
+          tags: ${{ steps.meta.outputs.tags }}


### PR DESCRIPTION
This fixes us trying to build docker images in the merge queue but also makes it so we can automerge docker image related shit because we can now validate that build automatically.