### PR TITLE
Remove Concurrency Checks from Validate Docker Build

### DIFF
--- a/.github/workflows/validate-docker-build.yml
+++ b/.github/workflows/validate-docker-build.yml
@@ -16,10 +16,6 @@ on:
   merge_group:
     branches: [main]
 
-concurrency:
-  group: docker-test-build-${{ github.ref }}
-  cancel-in-progress: true
-
 env:
   IMAGE_NAME: draupnir
   PLATFORMS: linux/amd64,linux/arm64


### PR DESCRIPTION
They aren't needed as this never pushes to anywhere so who cares if we run this a bit too aggressively to maintain perfect resolution of if the build works.

The reason this screw up made it is simple. Cat did not foresee this being problematic when the workflow its a carbon copy of did not act up.