### PR TITLE
Fix Docker Workflow Validator only running on main repo activity.

### DIFF
--- a/.github/workflows/validate-docker-build.yml
+++ b/.github/workflows/validate-docker-build.yml
@@ -13,6 +13,10 @@ on:
       - "github-actions/**"
   schedule:
     - cron: "20 20 * * *"
+  pull_request:
+    branches-ignore:
+      - "dependabot/**"
+      - "github-actions/**"
   merge_group:
     branches: [main]
 


### PR DESCRIPTION
This worked fine when the PR originated in the main repo but did not for external PRs and this workflow is safe for external due to no secrets access.

https://github.com/the-draupnir-project/Draupnir/pull/1158 was affected by this and this PR should fix that problem.