### PR TITLE
Remove the aliases for the matrix-protection-suite packages.

### DIFF
--- a/apps/draupnir/package.json
+++ b/apps/draupnir/package.json
@@ -46,6 +46,8 @@
     "@sinclair/typebox": "0.34.49",
     "@the-draupnir-project/interface-manager": "4.2.6",
     "@the-draupnir-project/matrix-basic-types": "1.5.1",
+    "@the-draupnir-project/matrix-protection-suite": "7.1.0",
+    "@the-draupnir-project/matrix-protection-suite-for-matrix-bot-sdk": "5.0.1",
     "@the-draupnir-project/mps-interface-adaptor": "0.6.0",
     "@vector-im/matrix-bot-sdk": "^0.8.0-element.3",
     "better-sqlite3": "^12.8.0",
@@ -56,15 +58,12 @@
     "js-yaml": "^4.1.0",
     "jsdom": "^24.0.0",
     "matrix-appservice-bridge": "^11.2.0",
-    "matrix-protection-suite": "npm:@the-draupnir-project/matrix-protection-suite@7.1.0",
-    "matrix-protection-suite-for-matrix-bot-sdk": "npm:@the-draupnir-project/matrix-protection-suite@5.0.1",
     "pg": "^8.8.0",
     "yaml": "^2.3.2"
   },
   "overrides": {
     "@the-draupnir-project/matrix-basic-types": "$the-draupnir-project/matrix-basic-types",
-    "@the-draupnir-project/interface-manager": "$the-draupnir-project/interface-manager",
-    "matrix-protection-suite": "$matrix-protection-suite"
+    "@the-draupnir-project/interface-manager": "$the-draupnir-project/interface-manager"
   },
   "engines": {
     "node": ">=24.0.0"

--- a/apps/draupnir/src/Draupnir.ts
+++ b/apps/draupnir/src/Draupnir.ts
@@ -28,7 +28,7 @@ import {
   Task,
   Value,
   isError,
-} from "matrix-protection-suite";
+} from "@the-draupnir-project/matrix-protection-suite";
 import { UnlistedUserRedactionQueue } from "./queues/UnlistedUserRedactionQueue";
 import { ThrottlingQueue } from "./queues/ThrottlingQueue";
 import ManagementRoomOutput from "./managementroom/ManagementRoomOutput";
@@ -37,7 +37,7 @@ import { StandardReportManager } from "./report/ReportManager";
 import {
   MatrixSendClient,
   SynapseAdminClient,
-} from "matrix-protection-suite-for-matrix-bot-sdk";
+} from "@the-draupnir-project/matrix-protection-suite-for-matrix-bot-sdk";
 import { IConfig } from "./config";
 import { LogLevel } from "@vector-im/matrix-bot-sdk";
 import { RendererMessageCollector } from "./capabilities/RendererMessageCollector";

--- a/apps/draupnir/src/DraupnirBotMode.ts
+++ b/apps/draupnir/src/DraupnirBotMode.ts
@@ -17,7 +17,7 @@ import {
   ActionException,
   ActionExceptionKind,
   ConfigRecoverableError,
-} from "matrix-protection-suite";
+} from "@the-draupnir-project/matrix-protection-suite";
 import {
   BotSDKMatrixAccountData,
   ClientCapabilityFactory,
@@ -25,7 +25,7 @@ import {
   RoomStateManagerFactory,
   SafeMatrixEmitter,
   joinedRoomsSafe,
-} from "matrix-protection-suite-for-matrix-bot-sdk";
+} from "@the-draupnir-project/matrix-protection-suite-for-matrix-bot-sdk";
 import { IConfig } from "./config";
 import { Draupnir } from "./Draupnir";
 import { DraupnirFactory } from "./draupnirfactory/DraupnirFactory";

--- a/apps/draupnir/src/appservice/AccessControl.ts
+++ b/apps/draupnir/src/appservice/AccessControl.ts
@@ -24,7 +24,7 @@ import {
   PolicyRuleType,
   Recommendation,
   RoomJoiner,
-} from "matrix-protection-suite";
+} from "@the-draupnir-project/matrix-protection-suite";
 
 /**
  * Utility to manage which users have access to the application service,

--- a/apps/draupnir/src/appservice/AppService.ts
+++ b/apps/draupnir/src/appservice/AppService.ts
@@ -33,7 +33,7 @@ import {
   joinedRoomsSafe,
   resultifyBotSDKRequestError,
   resultifyBotSDKRequestErrorWith404AsUndefined,
-} from "matrix-protection-suite-for-matrix-bot-sdk";
+} from "@the-draupnir-project/matrix-protection-suite-for-matrix-bot-sdk";
 import {
   ClientsInRoomMap,
   DefaultEventDecoder,
@@ -42,7 +42,7 @@ import {
   StandardClientsInRoomMap,
   Task,
   isError,
-} from "matrix-protection-suite";
+} from "@the-draupnir-project/matrix-protection-suite";
 import { AppServiceDraupnirManager } from "./AppServiceDraupnirManager";
 import {
   StringRoomID,

--- a/apps/draupnir/src/appservice/AppServiceDraupnirManager.ts
+++ b/apps/draupnir/src/appservice/AppServiceDraupnirManager.ts
@@ -28,7 +28,7 @@ import {
   Task,
   assertThrowableIsError,
   isError,
-} from "matrix-protection-suite";
+} from "@the-draupnir-project/matrix-protection-suite";
 import { Draupnir } from "../Draupnir";
 import {
   BotSDKMatrixAccountData,
@@ -36,7 +36,7 @@ import {
   ClientForUserID,
   joinedRoomsSafe,
   RoomStateManagerFactory,
-} from "matrix-protection-suite-for-matrix-bot-sdk";
+} from "@the-draupnir-project/matrix-protection-suite-for-matrix-bot-sdk";
 import {
   DraupnirFailType,
   StandardDraupnirManager,

--- a/apps/draupnir/src/appservice/bot/AccessCommands.tsx
+++ b/apps/draupnir/src/appservice/bot/AccessCommands.tsx
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { AppserviceAdaptorContext } from "./AppserviceBotPrerequisite";
-import { ActionResult } from "matrix-protection-suite";
+import { ActionResult } from "@the-draupnir-project/matrix-protection-suite";
 import {
   MatrixUserIDPresentationType,
   describeCommand,

--- a/apps/draupnir/src/appservice/bot/AppserviceBotHelp.tsx
+++ b/apps/draupnir/src/appservice/bot/AppserviceBotHelp.tsx
@@ -11,7 +11,10 @@ import {
   TopPresentationSchema,
   describeCommand,
 } from "@the-draupnir-project/interface-manager";
-import { ActionResult, Ok } from "matrix-protection-suite";
+import {
+  ActionResult,
+  Ok,
+} from "@the-draupnir-project/matrix-protection-suite";
 import { AppserviceBotCommands } from "./AppserviceBotCommandTable";
 import { AppserviceBotInterfaceAdaptor } from "./AppserviceBotInterfaceAdaptor";
 import {

--- a/apps/draupnir/src/appservice/bot/AppserviceBotPrerequisite.ts
+++ b/apps/draupnir/src/appservice/bot/AppserviceBotPrerequisite.ts
@@ -9,7 +9,7 @@
 
 import { MatrixAdaptorContext } from "@the-draupnir-project/mps-interface-adaptor";
 import { MjolnirAppService } from "../AppService";
-import { MatrixSendClient } from "matrix-protection-suite-for-matrix-bot-sdk";
+import { MatrixSendClient } from "@the-draupnir-project/matrix-protection-suite-for-matrix-bot-sdk";
 
 export interface AppserviceAdaptorContext extends MatrixAdaptorContext {
   appservice: MjolnirAppService;

--- a/apps/draupnir/src/appservice/bot/AppserviceCommandHandler.ts
+++ b/apps/draupnir/src/appservice/bot/AppserviceCommandHandler.ts
@@ -10,8 +10,8 @@ import {
   RoomMessage,
   Value,
   isError,
-} from "matrix-protection-suite";
-import { MatrixSendClient } from "matrix-protection-suite-for-matrix-bot-sdk";
+} from "@the-draupnir-project/matrix-protection-suite";
+import { MatrixSendClient } from "@the-draupnir-project/matrix-protection-suite-for-matrix-bot-sdk";
 import {
   StringUserID,
   StringRoomID,

--- a/apps/draupnir/src/appservice/bot/AvatarCommand.tsx
+++ b/apps/draupnir/src/appservice/bot/AvatarCommand.tsx
@@ -8,14 +8,14 @@ import {
   isError,
   Ok,
   ActionError,
-} from "matrix-protection-suite";
+} from "@the-draupnir-project/matrix-protection-suite";
 import {
   StringPresentationType,
   describeCommand,
 } from "@the-draupnir-project/interface-manager";
 import { isStringMediaURI } from "@the-draupnir-project/matrix-basic-types";
 import { AppserviceBotInterfaceAdaptor } from "./AppserviceBotInterfaceAdaptor";
-import { resultifyBotSDKRequestError } from "matrix-protection-suite-for-matrix-bot-sdk";
+import { resultifyBotSDKRequestError } from "@the-draupnir-project/matrix-protection-suite-for-matrix-bot-sdk";
 
 export const AppserviceAvatarCommand = describeCommand({
   summary: "Sets the avatar of the main appservice admin bot.",

--- a/apps/draupnir/src/appservice/bot/DisplaynameCommand.tsx
+++ b/apps/draupnir/src/appservice/bot/DisplaynameCommand.tsx
@@ -3,13 +3,17 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { AppserviceAdaptorContext } from "./AppserviceBotPrerequisite";
-import { ActionResult, isError, Ok } from "matrix-protection-suite";
+import {
+  ActionResult,
+  isError,
+  Ok,
+} from "@the-draupnir-project/matrix-protection-suite";
 import {
   StringPresentationType,
   describeCommand,
 } from "@the-draupnir-project/interface-manager";
 import { AppserviceBotInterfaceAdaptor } from "./AppserviceBotInterfaceAdaptor";
-import { resultifyBotSDKRequestError } from "matrix-protection-suite-for-matrix-bot-sdk";
+import { resultifyBotSDKRequestError } from "@the-draupnir-project/matrix-protection-suite-for-matrix-bot-sdk";
 
 export const AppserviceDisplaynameCommand = describeCommand({
   summary: "Sets the displayname of the main appservice admin bot.",

--- a/apps/draupnir/src/appservice/bot/ListCommand.tsx
+++ b/apps/draupnir/src/appservice/bot/ListCommand.tsx
@@ -7,7 +7,7 @@ import {
   ActionResult,
   isError,
   Ok,
-} from "matrix-protection-suite";
+} from "@the-draupnir-project/matrix-protection-suite";
 import { UnstartedDraupnir } from "../../draupnirfactory/StandardDraupnirManager";
 import { AppserviceAdaptorContext } from "./AppserviceBotPrerequisite";
 import {

--- a/apps/draupnir/src/appservice/bot/ProvisionCommand.tsx
+++ b/apps/draupnir/src/appservice/bot/ProvisionCommand.tsx
@@ -3,7 +3,11 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { AppserviceAdaptorContext } from "./AppserviceBotPrerequisite";
-import { ActionResult, isError, Ok } from "matrix-protection-suite";
+import {
+  ActionResult,
+  isError,
+  Ok,
+} from "@the-draupnir-project/matrix-protection-suite";
 import {
   MatrixUserIDPresentationType,
   describeCommand,

--- a/apps/draupnir/src/appservice/bot/VersionCommand.tsx
+++ b/apps/draupnir/src/appservice/bot/VersionCommand.tsx
@@ -3,7 +3,11 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { AppserviceAdaptorContext } from "./AppserviceBotPrerequisite";
-import { ActionResult, Ok, isError } from "matrix-protection-suite";
+import {
+  ActionResult,
+  Ok,
+  isError,
+} from "@the-draupnir-project/matrix-protection-suite";
 import {
   DeadDocumentJSX,
   describeCommand,

--- a/apps/draupnir/src/appservice/config/config.ts
+++ b/apps/draupnir/src/appservice/config/config.ts
@@ -13,8 +13,8 @@ import { Type } from "@sinclair/typebox";
 import * as fs from "fs";
 import { load } from "js-yaml";
 import { Value } from "@sinclair/typebox/value";
-import { EDStatic } from "matrix-protection-suite";
-import { StringUserIDSchema } from "matrix-protection-suite";
+import { EDStatic } from "@the-draupnir-project/matrix-protection-suite";
+import { StringUserIDSchema } from "@the-draupnir-project/matrix-protection-suite";
 
 export function read(configPath: string): AppserviceConfig {
   const content = fs.readFileSync(configPath, "utf8");

--- a/apps/draupnir/src/backingstore/DraupnirStores.ts
+++ b/apps/draupnir/src/backingstore/DraupnirStores.ts
@@ -2,7 +2,10 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-import { EventDecoder, SHA256HashStore } from "matrix-protection-suite";
+import {
+  EventDecoder,
+  SHA256HashStore,
+} from "@the-draupnir-project/matrix-protection-suite";
 import { RoomAuditLog } from "../protections/RoomTakedown/RoomAuditLog";
 import { SqliteRoomStateBackingStore } from "./better-sqlite3/SqliteRoomStateBackingStore";
 import { SqliteHashReversalStore } from "./better-sqlite3/HashStore";

--- a/apps/draupnir/src/backingstore/better-sqlite3/BetterSqliteStore.ts
+++ b/apps/draupnir/src/backingstore/better-sqlite3/BetterSqliteStore.ts
@@ -9,7 +9,7 @@
 // </text>
 
 import BetterSqlite3, { Database } from "better-sqlite3";
-import { Logger } from "matrix-protection-suite";
+import { Logger } from "@the-draupnir-project/matrix-protection-suite";
 import { ensureSqliteSchema, SqliteSchemaOptions } from "./SqliteSchema";
 
 export interface BetterSqliteOptions extends BetterSqlite3.Options {

--- a/apps/draupnir/src/backingstore/better-sqlite3/HashStore.ts
+++ b/apps/draupnir/src/backingstore/better-sqlite3/HashStore.ts
@@ -26,7 +26,7 @@ import {
   Logger,
   UserHashRecord,
   PolicyRuleType,
-} from "matrix-protection-suite";
+} from "@the-draupnir-project/matrix-protection-suite";
 import { BetterSqliteStore, makeBetterSqliteDB } from "./BetterSqliteStore";
 import { Database, Statement } from "better-sqlite3";
 import path from "path";

--- a/apps/draupnir/src/backingstore/better-sqlite3/SqliteRoomStateBackingStore.ts
+++ b/apps/draupnir/src/backingstore/better-sqlite3/SqliteRoomStateBackingStore.ts
@@ -15,7 +15,7 @@ import {
   StateEvent,
   assertThrowableIsError,
   isError,
-} from "matrix-protection-suite";
+} from "@the-draupnir-project/matrix-protection-suite";
 import {
   BetterSqliteOptions,
   BetterSqliteStore,

--- a/apps/draupnir/src/backingstore/better-sqlite3/SqliteSchema.ts
+++ b/apps/draupnir/src/backingstore/better-sqlite3/SqliteSchema.ts
@@ -4,7 +4,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { Database } from "better-sqlite3";
-import { Logger } from "matrix-protection-suite";
+import { Logger } from "@the-draupnir-project/matrix-protection-suite";
 
 export type SqliteSchemaOptions = {
   upgradeSteps: ((db: Database) => void)[];

--- a/apps/draupnir/src/capabilities/DraupnirRendererMessageCollector.tsx
+++ b/apps/draupnir/src/capabilities/DraupnirRendererMessageCollector.tsx
@@ -11,7 +11,7 @@ import {
   DescriptionMeta,
   RoomMessageSender,
   Task,
-} from "matrix-protection-suite";
+} from "@the-draupnir-project/matrix-protection-suite";
 import { StringRoomID } from "@the-draupnir-project/matrix-basic-types";
 import {
   DeadDocumentJSX,

--- a/apps/draupnir/src/capabilities/RendererMessageCollector.ts
+++ b/apps/draupnir/src/capabilities/RendererMessageCollector.ts
@@ -3,7 +3,10 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { DocumentNode } from "@the-draupnir-project/interface-manager";
-import { Capability, DescriptionMeta } from "matrix-protection-suite";
+import {
+  Capability,
+  DescriptionMeta,
+} from "@the-draupnir-project/matrix-protection-suite";
 
 export enum MessageType {
   Document = "Document",

--- a/apps/draupnir/src/capabilities/RoomTakedownCapability.tsx
+++ b/apps/draupnir/src/capabilities/RoomTakedownCapability.tsx
@@ -10,7 +10,7 @@ import {
   CapabilityMethodSchema,
   describeCapabilityInterface,
   RoomBasicDetails,
-} from "matrix-protection-suite";
+} from "@the-draupnir-project/matrix-protection-suite";
 
 export interface RoomDetailsProvider {
   getRoomDetails(roomID: StringRoomID): Promise<Result<RoomBasicDetails>>;

--- a/apps/draupnir/src/capabilities/RoomTakedownCapabilityRenderer.tsx
+++ b/apps/draupnir/src/capabilities/RoomTakedownCapabilityRenderer.tsx
@@ -6,7 +6,7 @@ import {
   describeCapabilityRenderer,
   DescriptionMeta,
   RoomBasicDetails,
-} from "matrix-protection-suite";
+} from "@the-draupnir-project/matrix-protection-suite";
 import { RoomTakedownCapability } from "./RoomTakedownCapability";
 import { RendererMessageCollector } from "./RendererMessageCollector";
 import {

--- a/apps/draupnir/src/capabilities/ServerACLConsequencesRenderer.tsx
+++ b/apps/draupnir/src/capabilities/ServerACLConsequencesRenderer.tsx
@@ -19,7 +19,7 @@ import {
   describeCapabilityContextGlue,
   describeCapabilityRenderer,
   isError,
-} from "matrix-protection-suite";
+} from "@the-draupnir-project/matrix-protection-suite";
 import { RendererMessageCollector } from "./RendererMessageCollector";
 import { Draupnir } from "../Draupnir";
 import {

--- a/apps/draupnir/src/capabilities/StandardEventConsequencesRenderer.tsx
+++ b/apps/draupnir/src/capabilities/StandardEventConsequencesRenderer.tsx
@@ -17,7 +17,7 @@ import {
   describeCapabilityContextGlue,
   describeCapabilityRenderer,
   isError,
-} from "matrix-protection-suite";
+} from "@the-draupnir-project/matrix-protection-suite";
 import { RendererMessageCollector } from "./RendererMessageCollector";
 import { Draupnir } from "../Draupnir";
 import {

--- a/apps/draupnir/src/capabilities/StandardUserConsequencesRenderer.tsx
+++ b/apps/draupnir/src/capabilities/StandardUserConsequencesRenderer.tsx
@@ -22,7 +22,7 @@ import {
   describeCapabilityContextGlue,
   describeCapabilityRenderer,
   isError,
-} from "matrix-protection-suite";
+} from "@the-draupnir-project/matrix-protection-suite";
 import { RendererMessageCollector } from "./RendererMessageCollector";
 import { Draupnir } from "../Draupnir";
 import {

--- a/apps/draupnir/src/capabilities/SynapseAdminRoomTakedown/SynapseAdminRoomTakedown.ts
+++ b/apps/draupnir/src/capabilities/SynapseAdminRoomTakedown/SynapseAdminRoomTakedown.ts
@@ -7,12 +7,12 @@ import {
   describeCapabilityProvider,
   Logger,
   RoomBasicDetails,
-} from "matrix-protection-suite";
+} from "@the-draupnir-project/matrix-protection-suite";
 import {
   RoomDetailsProvider,
   RoomTakedownCapability,
 } from "../RoomTakedownCapability";
-import { SynapseAdminClient } from "matrix-protection-suite-for-matrix-bot-sdk";
+import { SynapseAdminClient } from "@the-draupnir-project/matrix-protection-suite-for-matrix-bot-sdk";
 import { isError, Ok, Result } from "@gnuxie/typescript-result";
 import { Draupnir } from "../../Draupnir";
 import "../RoomTakedownCapability"; // needed for the interface to load.

--- a/apps/draupnir/src/commands/AliasCommands.ts
+++ b/apps/draupnir/src/commands/AliasCommands.ts
@@ -8,7 +8,11 @@
 // https://github.com/matrix-org/mjolnir
 // </text>
 
-import { ActionResult, isError, Ok } from "matrix-protection-suite";
+import {
+  ActionResult,
+  isError,
+  Ok,
+} from "@the-draupnir-project/matrix-protection-suite";
 import { Draupnir } from "../Draupnir";
 import {
   describeCommand,
@@ -17,7 +21,7 @@ import {
   MatrixRoomReferencePresentationSchema,
 } from "@the-draupnir-project/interface-manager";
 import { DraupnirInterfaceAdaptor } from "./DraupnirCommandPrerequisites";
-import { resultifyBotSDKRequestError } from "matrix-protection-suite-for-matrix-bot-sdk";
+import { resultifyBotSDKRequestError } from "@the-draupnir-project/matrix-protection-suite-for-matrix-bot-sdk";
 
 export const DraupnirAliasAddCommand = describeCommand({
   summary: "Add a new alias to the room on Draupnir's homeserver",

--- a/apps/draupnir/src/commands/Ban.tsx
+++ b/apps/draupnir/src/commands/Ban.tsx
@@ -17,7 +17,7 @@ import {
   PolicyRoomManager,
   RoomResolver,
   WatchedPolicyRooms,
-} from "matrix-protection-suite";
+} from "@the-draupnir-project/matrix-protection-suite";
 import {
   MatrixRoomReference,
   MatrixUserID,

--- a/apps/draupnir/src/commands/CreateBanListCommand.ts
+++ b/apps/draupnir/src/commands/CreateBanListCommand.ts
@@ -8,7 +8,10 @@
 // https://github.com/matrix-org/mjolnir
 // </text>
 
-import { ActionResult, isError } from "matrix-protection-suite";
+import {
+  ActionResult,
+  isError,
+} from "@the-draupnir-project/matrix-protection-suite";
 import { Draupnir } from "../Draupnir";
 import { MatrixRoomID } from "@the-draupnir-project/matrix-basic-types";
 import {

--- a/apps/draupnir/src/commands/Help.tsx
+++ b/apps/draupnir/src/commands/Help.tsx
@@ -13,11 +13,11 @@ import {
   CommandTable,
   DocumentNode,
   DeadDocumentJSX,
+  TopPresentationSchema,
   describeCommand,
   describeRestParameters,
 } from "@the-draupnir-project/interface-manager";
 import { DraupnirTopLevelCommands } from "./DraupnirCommandTable";
-import { TopPresentationSchema } from "@the-draupnir-project/interface-manager/dist/Command/PresentationSchema";
 import { renderTableHelp } from "@the-draupnir-project/mps-interface-adaptor";
 import { DraupnirInterfaceAdaptor } from "./DraupnirCommandPrerequisites";
 import { DOCUMENTATION_URL } from "../config";

--- a/apps/draupnir/src/commands/Help.tsx
+++ b/apps/draupnir/src/commands/Help.tsx
@@ -8,7 +8,7 @@
 // https://github.com/matrix-org/mjolnir
 // </text>
 
-import { Ok } from "matrix-protection-suite";
+import { Ok } from "@the-draupnir-project/matrix-protection-suite";
 import {
   CommandTable,
   DocumentNode,

--- a/apps/draupnir/src/commands/ImportCommand.ts
+++ b/apps/draupnir/src/commands/ImportCommand.ts
@@ -19,8 +19,8 @@ import {
   StateEvent,
   Value,
   isError,
-} from "matrix-protection-suite";
-import { resolveRoomReferenceSafe } from "matrix-protection-suite-for-matrix-bot-sdk";
+} from "@the-draupnir-project/matrix-protection-suite";
+import { resolveRoomReferenceSafe } from "@the-draupnir-project/matrix-protection-suite-for-matrix-bot-sdk";
 import {
   MatrixRoomReferencePresentationSchema,
   describeCommand,

--- a/apps/draupnir/src/commands/KickCommand.tsx
+++ b/apps/draupnir/src/commands/KickCommand.tsx
@@ -17,7 +17,7 @@ import {
   SetRoomMembership,
   isError,
   Membership,
-} from "matrix-protection-suite";
+} from "@the-draupnir-project/matrix-protection-suite";
 import {
   StringUserID,
   StringRoomID,

--- a/apps/draupnir/src/commands/ProtectionsCapabilitiesCommand.tsx
+++ b/apps/draupnir/src/commands/ProtectionsCapabilitiesCommand.tsx
@@ -14,7 +14,7 @@ import {
   ProtectionDescription,
   findCapabilityProvider,
   findProtection,
-} from "matrix-protection-suite";
+} from "@the-draupnir-project/matrix-protection-suite";
 import { Draupnir } from "../Draupnir";
 import { DraupnirInterfaceAdaptor } from "./DraupnirCommandPrerequisites";
 

--- a/apps/draupnir/src/commands/ProtectionsCommands.tsx
+++ b/apps/draupnir/src/commands/ProtectionsCommands.tsx
@@ -23,7 +23,7 @@ import {
   findProtection,
   getAllProtections,
   isError,
-} from "matrix-protection-suite";
+} from "@the-draupnir-project/matrix-protection-suite";
 import { Draupnir } from "../Draupnir";
 import {
   DeadDocumentJSX,

--- a/apps/draupnir/src/commands/ProtectionsShowCommand.tsx
+++ b/apps/draupnir/src/commands/ProtectionsShowCommand.tsx
@@ -18,7 +18,7 @@ import {
   ProtectionDescription,
   findCompatibleCapabilityProviders,
   findProtection,
-} from "matrix-protection-suite";
+} from "@the-draupnir-project/matrix-protection-suite";
 import { DraupnirInterfaceAdaptor } from "./DraupnirCommandPrerequisites";
 import { StandardPersistentConfigRenderer } from "../safemode/PersistentConfigRenderer";
 

--- a/apps/draupnir/src/commands/RedactCommand.ts
+++ b/apps/draupnir/src/commands/RedactCommand.ts
@@ -8,9 +8,13 @@
 // https://github.com/matrix-org/mjolnir
 // </text>
 
-import { ActionResult, Ok, isError } from "matrix-protection-suite";
+import {
+  ActionResult,
+  Ok,
+  isError,
+} from "@the-draupnir-project/matrix-protection-suite";
 import { redactUserMessagesIn } from "../utils";
-import { resolveRoomReferenceSafe } from "matrix-protection-suite-for-matrix-bot-sdk";
+import { resolveRoomReferenceSafe } from "@the-draupnir-project/matrix-protection-suite-for-matrix-bot-sdk";
 import { Draupnir } from "../Draupnir";
 import {
   MatrixEventReference,

--- a/apps/draupnir/src/commands/Rooms.tsx
+++ b/apps/draupnir/src/commands/Rooms.tsx
@@ -17,7 +17,7 @@ import {
   WatchedPolicyRoom,
   assertThrowableIsError,
   isError,
-} from "matrix-protection-suite";
+} from "@the-draupnir-project/matrix-protection-suite";
 import {
   MatrixRoomID,
   MatrixRoomReference,

--- a/apps/draupnir/src/commands/Rules.tsx
+++ b/apps/draupnir/src/commands/Rules.tsx
@@ -18,7 +18,7 @@ import {
   PolicyRule,
   PolicyRuleMatchType,
   isError,
-} from "matrix-protection-suite";
+} from "@the-draupnir-project/matrix-protection-suite";
 import {
   StringRoomID,
   MatrixRoomID,

--- a/apps/draupnir/src/commands/SetAvatarCommand.ts
+++ b/apps/draupnir/src/commands/SetAvatarCommand.ts
@@ -10,8 +10,8 @@ import {
 import { isStringMediaURI } from "@the-draupnir-project/matrix-basic-types";
 import { Draupnir } from "../Draupnir";
 import { DraupnirInterfaceAdaptor } from "./DraupnirCommandPrerequisites";
-import { resultifyBotSDKRequestError } from "matrix-protection-suite-for-matrix-bot-sdk";
-import { ActionError } from "matrix-protection-suite";
+import { resultifyBotSDKRequestError } from "@the-draupnir-project/matrix-protection-suite-for-matrix-bot-sdk";
+import { ActionError } from "@the-draupnir-project/matrix-protection-suite";
 
 export const DraupnirAvatarCommand = describeCommand({
   summary:

--- a/apps/draupnir/src/commands/SetDisplayNameCommand.ts
+++ b/apps/draupnir/src/commands/SetDisplayNameCommand.ts
@@ -9,7 +9,7 @@ import {
 } from "@the-draupnir-project/interface-manager";
 import { Draupnir } from "../Draupnir";
 import { DraupnirInterfaceAdaptor } from "./DraupnirCommandPrerequisites";
-import { resultifyBotSDKRequestError } from "matrix-protection-suite-for-matrix-bot-sdk";
+import { resultifyBotSDKRequestError } from "@the-draupnir-project/matrix-protection-suite-for-matrix-bot-sdk";
 
 export const DraupnirDisplaynameCommand = describeCommand({
   summary:

--- a/apps/draupnir/src/commands/StatusCommand.tsx
+++ b/apps/draupnir/src/commands/StatusCommand.tsx
@@ -21,7 +21,7 @@ import {
   WatchedPolicyRoom,
   WatchedPolicyRooms,
   isError,
-} from "matrix-protection-suite";
+} from "@the-draupnir-project/matrix-protection-suite";
 import { Draupnir } from "../Draupnir";
 import {
   DeadDocumentJSX,

--- a/apps/draupnir/src/commands/WatchPreview.tsx
+++ b/apps/draupnir/src/commands/WatchPreview.tsx
@@ -23,7 +23,7 @@ import {
   SetMembershipRevision,
   ServerBanSynchronisationProtection,
   ServerBanIntentProjectionDelta,
-} from "matrix-protection-suite";
+} from "@the-draupnir-project/matrix-protection-suite";
 
 function watchDeltaForMemberBanIntents(
   setMembershipPoliciesRevision: SetMembershipPolicyRevision,

--- a/apps/draupnir/src/commands/WatchUnwatchCommand.ts
+++ b/apps/draupnir/src/commands/WatchUnwatchCommand.ts
@@ -14,7 +14,7 @@ import {
   RoomJoiner,
   WatchedPolicyRooms,
   isError,
-} from "matrix-protection-suite";
+} from "@the-draupnir-project/matrix-protection-suite";
 import {
   MatrixRoomReferencePresentationSchema,
   describeCommand,

--- a/apps/draupnir/src/commands/server-admin/DeactivateCommand.tsx
+++ b/apps/draupnir/src/commands/server-admin/DeactivateCommand.tsx
@@ -22,7 +22,7 @@ import {
   LiteralPolicyRule,
   Logger,
   Task,
-} from "matrix-protection-suite";
+} from "@the-draupnir-project/matrix-protection-suite";
 import { Draupnir } from "../../Draupnir";
 import { DraupnirInterfaceAdaptor } from "../DraupnirCommandPrerequisites";
 import { deactivateUser } from "../../protections/HomeserverUserPolicyApplication/deactivateUser";

--- a/apps/draupnir/src/commands/server-admin/HijackRoomCommand.ts
+++ b/apps/draupnir/src/commands/server-admin/HijackRoomCommand.ts
@@ -13,8 +13,8 @@ import {
   ActionResult,
   Ok,
   isError,
-} from "matrix-protection-suite";
-import { resolveRoomReferenceSafe } from "matrix-protection-suite-for-matrix-bot-sdk";
+} from "@the-draupnir-project/matrix-protection-suite";
+import { resolveRoomReferenceSafe } from "@the-draupnir-project/matrix-protection-suite-for-matrix-bot-sdk";
 import {
   MatrixRoomReferencePresentationSchema,
   MatrixUserIDPresentationType,

--- a/apps/draupnir/src/commands/server-admin/ShutdownRoomCommand.ts
+++ b/apps/draupnir/src/commands/server-admin/ShutdownRoomCommand.ts
@@ -16,7 +16,7 @@ import {
   tuple,
 } from "@the-draupnir-project/interface-manager";
 import { Draupnir } from "../../Draupnir";
-import { ActionError } from "matrix-protection-suite";
+import { ActionError } from "@the-draupnir-project/matrix-protection-suite";
 import { DraupnirInterfaceAdaptor } from "../DraupnirCommandPrerequisites";
 
 export const SynapseAdminShutdownRoomCommand = describeCommand({

--- a/apps/draupnir/src/commands/server-admin/Takedown.tsx
+++ b/apps/draupnir/src/commands/server-admin/Takedown.tsx
@@ -26,7 +26,7 @@ import {
   RoomResolver,
   SHA256HashStore,
   WatchedPolicyRooms,
-} from "matrix-protection-suite";
+} from "@the-draupnir-project/matrix-protection-suite";
 import { Result, ResultError } from "@gnuxie/typescript-result";
 import {
   MatrixRoomID,

--- a/apps/draupnir/src/commands/unban/PolicyRemove.tsx
+++ b/apps/draupnir/src/commands/unban/PolicyRemove.tsx
@@ -22,7 +22,7 @@ import {
   Recommendation,
   StringTypeResult,
   StringTypeResultBuilder,
-} from "matrix-protection-suite";
+} from "@the-draupnir-project/matrix-protection-suite";
 import { isError, Result, ResultError } from "@gnuxie/typescript-result";
 import { findPolicyRoomEditorFromRoomReference } from "../Ban";
 import {

--- a/apps/draupnir/src/commands/unban/Unban.tsx
+++ b/apps/draupnir/src/commands/unban/Unban.tsx
@@ -20,7 +20,7 @@ import {
   SetMembershipRevisionIssuer,
   SetRoomMembership,
   WatchedPolicyRooms,
-} from "matrix-protection-suite";
+} from "@the-draupnir-project/matrix-protection-suite";
 import {
   MatrixRoomID,
   MatrixUserID,

--- a/apps/draupnir/src/commands/unban/UnbanEntity.tsx
+++ b/apps/draupnir/src/commands/unban/UnbanEntity.tsx
@@ -17,7 +17,7 @@ import {
   Recommendation,
   RoomSetResultBuilder,
   WatchedPolicyRooms,
-} from "matrix-protection-suite";
+} from "@the-draupnir-project/matrix-protection-suite";
 import { ListMatches } from "../Rules";
 import { isError, Ok, Result } from "@gnuxie/typescript-result";
 import { UnbanEntityPreview, UnbanEntityResult } from "./Unban";

--- a/apps/draupnir/src/commands/unban/UnbanUsers.tsx
+++ b/apps/draupnir/src/commands/unban/UnbanUsers.tsx
@@ -29,7 +29,7 @@ import {
   PolicyRuleType,
   PolicyRuleMatchType,
   PolicyListRevision,
-} from "matrix-protection-suite";
+} from "@the-draupnir-project/matrix-protection-suite";
 import { UnlistedUserRedactionQueue } from "../../queues/UnlistedUserRedactionQueue";
 import { ListMatches } from "../Rules";
 import { MemberRooms, UnbanMembersPreview, UnbanMembersResult } from "./Unban";

--- a/apps/draupnir/src/config.ts
+++ b/apps/draupnir/src/config.ts
@@ -18,7 +18,10 @@ process.env.SUPPRESS_NO_CONFIG_WARNING = "y";
 import Config from "config";
 import path from "path";
 import { SafeModeBootOption } from "./safemode/BootOption";
-import { Logger, setGlobalLoggerProvider } from "matrix-protection-suite";
+import {
+  Logger,
+  setGlobalLoggerProvider,
+} from "@the-draupnir-project/matrix-protection-suite";
 
 LogService.setLogger(new RichConsoleLogger());
 setGlobalLoggerProvider(new RichConsoleLogger());

--- a/apps/draupnir/src/draupnirfactory/DraupnirFactory.ts
+++ b/apps/draupnir/src/draupnirfactory/DraupnirFactory.ts
@@ -9,7 +9,7 @@ import {
   Ok,
   StandardLoggableConfigTracker,
   isError,
-} from "matrix-protection-suite";
+} from "@the-draupnir-project/matrix-protection-suite";
 import { Draupnir } from "../Draupnir";
 import {
   ClientCapabilityFactory,
@@ -18,7 +18,7 @@ import {
   RoomStateManagerFactory,
   joinedRoomsSafe,
   resultifyBotSDKRequestErrorWith404AsUndefined,
-} from "matrix-protection-suite-for-matrix-bot-sdk";
+} from "@the-draupnir-project/matrix-protection-suite-for-matrix-bot-sdk";
 import { IConfig } from "../config";
 import { makeProtectedRoomsSet } from "./DraupnirProtectedRoomsSet";
 import {

--- a/apps/draupnir/src/draupnirfactory/DraupnirProtectedRoomsSet.ts
+++ b/apps/draupnir/src/draupnirfactory/DraupnirProtectedRoomsSet.ts
@@ -42,12 +42,12 @@ import {
   StandardSetRoomState,
   StandardWatchedPolicyRooms,
   isError,
-} from "matrix-protection-suite";
+} from "@the-draupnir-project/matrix-protection-suite";
 import {
   BotSDKAccountDataConfigBackend,
   BotSDKRoomStateConfigBackend,
   MatrixSendClient,
-} from "matrix-protection-suite-for-matrix-bot-sdk";
+} from "@the-draupnir-project/matrix-protection-suite-for-matrix-bot-sdk";
 import { DefaultEnabledProtectionsMigration } from "../protections/ConfigMigration/DefaultEnabledProtectionsMigration";
 import "../protections/DraupnirProtectionsIndex";
 import { IConfig } from "../config";

--- a/apps/draupnir/src/draupnirfactory/StandardDraupnirManager.ts
+++ b/apps/draupnir/src/draupnirfactory/StandardDraupnirManager.ts
@@ -14,7 +14,7 @@ import {
   ConfigRecoverableError,
   Logger,
   isError,
-} from "matrix-protection-suite";
+} from "@the-draupnir-project/matrix-protection-suite";
 import { IConfig } from "../config";
 import { DraupnirFactory } from "./DraupnirFactory";
 import { Draupnir } from "../Draupnir";

--- a/apps/draupnir/src/index.ts
+++ b/apps/draupnir/src/index.ts
@@ -22,8 +22,8 @@ import { StoreType } from "@matrix-org/matrix-sdk-crypto-nodejs";
 import { configRead as configRead, getStoragePath } from "./config";
 import { initializeSentry } from "./utils";
 import { DraupnirBotModeToggle } from "./DraupnirBotMode";
-import { SafeMatrixEmitterWrapper } from "matrix-protection-suite-for-matrix-bot-sdk";
-import { DefaultEventDecoder } from "matrix-protection-suite";
+import { SafeMatrixEmitterWrapper } from "@the-draupnir-project/matrix-protection-suite-for-matrix-bot-sdk";
+import { DefaultEventDecoder } from "@the-draupnir-project/matrix-protection-suite";
 import { makeTopLevelStores } from "./backingstore/DraupnirStores";
 
 void (async function () {

--- a/apps/draupnir/src/managedRoomAccountData.ts
+++ b/apps/draupnir/src/managedRoomAccountData.ts
@@ -21,7 +21,7 @@ import {
   RoomCreator,
   RoomIDPermalinkSchema,
   RoomVersionMirror,
-} from "matrix-protection-suite";
+} from "@the-draupnir-project/matrix-protection-suite";
 
 export const ZERO_TOUCH_DEPLOY_ROOM_ACCOUNT_DATA_TYPE =
   "space.draupnir.zero_touch_deploy_room";

--- a/apps/draupnir/src/managementroom/ManagementRoomDetail.ts
+++ b/apps/draupnir/src/managementroom/ManagementRoomDetail.ts
@@ -16,7 +16,7 @@ import {
   RoomCreateEvent,
   RoomMembershipRevisionIssuer,
   RoomStateRevisionIssuer,
-} from "matrix-protection-suite";
+} from "@the-draupnir-project/matrix-protection-suite";
 
 export interface ManagementRoomDetail {
   isRoomPublic(): boolean;

--- a/apps/draupnir/src/managementroom/ManagementRoomOutput.ts
+++ b/apps/draupnir/src/managementroom/ManagementRoomOutput.ts
@@ -17,7 +17,7 @@ import {
 } from "@vector-im/matrix-bot-sdk";
 import { IConfig } from "../config";
 import { htmlEscape } from "../utils";
-import { MatrixSendClient } from "matrix-protection-suite-for-matrix-bot-sdk";
+import { MatrixSendClient } from "@the-draupnir-project/matrix-protection-suite-for-matrix-bot-sdk";
 import {
   StringRoomID,
   StringUserID,
@@ -27,7 +27,7 @@ import {
   MatrixRoomID,
 } from "@the-draupnir-project/matrix-basic-types";
 import { ManagementRoomDetail } from "./ManagementRoomDetail";
-import { Task } from "matrix-protection-suite";
+import { Task } from "@the-draupnir-project/matrix-protection-suite";
 
 const levelToFn = {
   [LogLevel.DEBUG.toString()]: LogService.debug,

--- a/apps/draupnir/src/models/RoomUpdateError.tsx
+++ b/apps/draupnir/src/models/RoomUpdateError.tsx
@@ -18,7 +18,7 @@ import {
   RoomMessageSender,
   RoomUpdateError,
   isError,
-} from "matrix-protection-suite";
+} from "@the-draupnir-project/matrix-protection-suite";
 import { sendMatrixEventsFromDeadDocument } from "@the-draupnir-project/mps-interface-adaptor";
 import { Result } from "@gnuxie/typescript-result";
 

--- a/apps/draupnir/src/protections/BanPropagation.tsx
+++ b/apps/draupnir/src/protections/BanPropagation.tsx
@@ -33,9 +33,9 @@ import {
   allocateProtection,
   OwnLifetime,
   Protection,
-} from "matrix-protection-suite";
+} from "@the-draupnir-project/matrix-protection-suite";
 import { Draupnir } from "../Draupnir";
-import { resolveRoomReferenceSafe } from "matrix-protection-suite-for-matrix-bot-sdk";
+import { resolveRoomReferenceSafe } from "@the-draupnir-project/matrix-protection-suite-for-matrix-bot-sdk";
 import { DraupnirProtection } from "./Protection";
 import {
   MatrixRoomID,

--- a/apps/draupnir/src/protections/BasicFlooding.ts
+++ b/apps/draupnir/src/protections/BasicFlooding.ts
@@ -32,7 +32,7 @@ import {
   UserConsequences,
   describeProtection,
   isError,
-} from "matrix-protection-suite";
+} from "@the-draupnir-project/matrix-protection-suite";
 import { Type } from "@sinclair/typebox";
 
 const log = new Logger("BasicFloodingProtection");

--- a/apps/draupnir/src/protections/BlockInvitationsOnServerProtection.tsx
+++ b/apps/draupnir/src/protections/BlockInvitationsOnServerProtection.tsx
@@ -15,7 +15,7 @@ import {
   Recommendation,
   UnknownConfig,
   WatchedPolicyRooms,
-} from "matrix-protection-suite";
+} from "@the-draupnir-project/matrix-protection-suite";
 import { BlockingCallback } from "../webapis/SynapseHTTPAntispam/SpamCheckEndpointPluginManager";
 import { UserMayInviteListenerArguments } from "../webapis/SynapseHTTPAntispam/UserMayInviteEndpoint";
 import { createHash } from "crypto";

--- a/apps/draupnir/src/protections/ConfigHooks.ts
+++ b/apps/draupnir/src/protections/ConfigHooks.ts
@@ -8,7 +8,7 @@ import {
   ProtectionsConfig,
   ServerBanSynchronisationProtection,
   isError,
-} from "matrix-protection-suite";
+} from "@the-draupnir-project/matrix-protection-suite";
 import { IConfig } from "../config";
 import { RoomTakedownProtection } from "./RoomTakedown/RoomTakedownProtection";
 import { BlockInvitationsOnServerProtection } from "./BlockInvitationsOnServerProtection";

--- a/apps/draupnir/src/protections/ConfigMigration/CapabilitySetProviderMigration.ts
+++ b/apps/draupnir/src/protections/ConfigMigration/CapabilitySetProviderMigration.ts
@@ -11,7 +11,7 @@ import {
   ServerACLSynchronisationCapability,
   SimulatedServerBanSynchronisationCapability,
   Value,
-} from "matrix-protection-suite";
+} from "@the-draupnir-project/matrix-protection-suite";
 
 const log = new Logger("CapabilitySetProviderMigration");
 

--- a/apps/draupnir/src/protections/ConfigMigration/DefaultEnabledProtectionsMigration.ts
+++ b/apps/draupnir/src/protections/ConfigMigration/DefaultEnabledProtectionsMigration.ts
@@ -13,7 +13,7 @@ import {
   SchemedDataManager,
   Value,
   findProtection,
-} from "matrix-protection-suite";
+} from "@the-draupnir-project/matrix-protection-suite";
 import { RedactionSynchronisationProtection } from "../RedactionSynchronisation";
 import { PolicyChangeNotification } from "../PolicyChangeNotification";
 import { JoinRoomsOnInviteProtection } from "../invitation/JoinRoomsOnInviteProtection";

--- a/apps/draupnir/src/protections/DraupnirNews/DraupnirNews.tsx
+++ b/apps/draupnir/src/protections/DraupnirNews/DraupnirNews.tsx
@@ -22,7 +22,7 @@ import {
   ProtectionDescription,
   StandardTimedGate,
   Value,
-} from "matrix-protection-suite";
+} from "@the-draupnir-project/matrix-protection-suite";
 import { Draupnir } from "../../Draupnir";
 import { DraupnirProtection } from "../Protection";
 

--- a/apps/draupnir/src/protections/FirstMessageIsImage.ts
+++ b/apps/draupnir/src/protections/FirstMessageIsImage.ts
@@ -27,7 +27,7 @@ import {
   UserConsequences,
   Value,
   describeProtection,
-} from "matrix-protection-suite";
+} from "@the-draupnir-project/matrix-protection-suite";
 import { Draupnir } from "../Draupnir";
 import {
   MatrixRoomID,

--- a/apps/draupnir/src/protections/HomeserverUserPolicyApplication/HomeserverUserPolicyApplication.ts
+++ b/apps/draupnir/src/protections/HomeserverUserPolicyApplication/HomeserverUserPolicyApplication.ts
@@ -21,7 +21,7 @@ import {
   Recommendation,
   Task,
   WatchedPolicyRooms,
-} from "matrix-protection-suite";
+} from "@the-draupnir-project/matrix-protection-suite";
 import { UserRestrictionCapability } from "./UserRestrictionCapability";
 import { UserRestrictionAuditLog } from "./UserRestrictionAuditLog";
 import { sendPromptDeactivation } from "../../commands/server-admin/DeactivateCommand";

--- a/apps/draupnir/src/protections/HomeserverUserPolicyApplication/HomeserverUserPolicyProtection.ts
+++ b/apps/draupnir/src/protections/HomeserverUserPolicyApplication/HomeserverUserPolicyProtection.ts
@@ -13,7 +13,7 @@ import {
   ProtectedRoomsSet,
   Protection,
   ProtectionDescription,
-} from "matrix-protection-suite";
+} from "@the-draupnir-project/matrix-protection-suite";
 import { UserRestrictionCapability } from "./UserRestrictionCapability";
 import { Draupnir } from "../../Draupnir";
 import { UserRestrictionAuditLog } from "./UserRestrictionAuditLog";

--- a/apps/draupnir/src/protections/HomeserverUserPolicyApplication/HomeserverUserPurgingDeactivate.ts
+++ b/apps/draupnir/src/protections/HomeserverUserPolicyApplication/HomeserverUserPurgingDeactivate.ts
@@ -16,8 +16,8 @@ import {
   LiteralPolicyRule,
   Logger,
   StandardBatcher,
-} from "matrix-protection-suite";
-import { SynapseAdminClient } from "matrix-protection-suite-for-matrix-bot-sdk";
+} from "@the-draupnir-project/matrix-protection-suite";
+import { SynapseAdminClient } from "@the-draupnir-project/matrix-protection-suite-for-matrix-bot-sdk";
 import { deactivateUser } from "./deactivateUser";
 import { UserRestrictionAuditLog } from "./UserRestrictionAuditLog";
 import { UserDetailsResponse } from "matrix-protection-suite-for-matrix-bot-sdk/dist/SynapseAdmin/UserDetailsEndpoint";

--- a/apps/draupnir/src/protections/HomeserverUserPolicyApplication/HomeserverUserPurgingDeactivate.ts
+++ b/apps/draupnir/src/protections/HomeserverUserPolicyApplication/HomeserverUserPurgingDeactivate.ts
@@ -17,10 +17,12 @@ import {
   Logger,
   StandardBatcher,
 } from "@the-draupnir-project/matrix-protection-suite";
-import { SynapseAdminClient } from "@the-draupnir-project/matrix-protection-suite-for-matrix-bot-sdk";
+import {
+  SynapseAdminClient,
+  UserDetailsResponse,
+} from "@the-draupnir-project/matrix-protection-suite-for-matrix-bot-sdk";
 import { deactivateUser } from "./deactivateUser";
 import { UserRestrictionAuditLog } from "./UserRestrictionAuditLog";
-import { UserDetailsResponse } from "matrix-protection-suite-for-matrix-bot-sdk/dist/SynapseAdmin/UserDetailsEndpoint";
 
 const log = new Logger("HomeserverUserPurgingDeactivate");
 

--- a/apps/draupnir/src/protections/HomeserverUserPolicyApplication/SqliteUserRestrictionAuditLog.ts
+++ b/apps/draupnir/src/protections/HomeserverUserPolicyApplication/SqliteUserRestrictionAuditLog.ts
@@ -9,7 +9,7 @@ import {
   ActionResult,
   LiteralPolicyRule,
   Logger,
-} from "matrix-protection-suite";
+} from "@the-draupnir-project/matrix-protection-suite";
 import { UserRestrictionAuditLog } from "./UserRestrictionAuditLog";
 import {
   checkKnownTables,
@@ -21,7 +21,7 @@ import {
 } from "../../backingstore/better-sqlite3/BetterSqliteStore";
 import { Database } from "better-sqlite3";
 import { Ok, Result } from "@gnuxie/typescript-result";
-import { AccountRestriction } from "matrix-protection-suite-for-matrix-bot-sdk";
+import { AccountRestriction } from "@the-draupnir-project/matrix-protection-suite-for-matrix-bot-sdk";
 import path from "path";
 
 const log = new Logger("SqliteUserAuditLog");

--- a/apps/draupnir/src/protections/HomeserverUserPolicyApplication/UserRestrictionAuditLog.ts
+++ b/apps/draupnir/src/protections/HomeserverUserPolicyApplication/UserRestrictionAuditLog.ts
@@ -4,8 +4,8 @@
 
 import { Result } from "@gnuxie/typescript-result";
 import { StringUserID } from "@the-draupnir-project/matrix-basic-types";
-import { LiteralPolicyRule } from "matrix-protection-suite";
-import { AccountRestriction } from "matrix-protection-suite-for-matrix-bot-sdk";
+import { LiteralPolicyRule } from "@the-draupnir-project/matrix-protection-suite";
+import { AccountRestriction } from "@the-draupnir-project/matrix-protection-suite-for-matrix-bot-sdk";
 
 export interface UserRestrictionAuditLog {
   isUserRestricted(userID: StringUserID): Promise<Result<boolean>>;

--- a/apps/draupnir/src/protections/HomeserverUserPolicyApplication/UserRestrictionCapability.ts
+++ b/apps/draupnir/src/protections/HomeserverUserPolicyApplication/UserRestrictionCapability.ts
@@ -10,8 +10,8 @@ import {
   CapabilityMethodSchema,
   describeCapabilityInterface,
   LiteralPolicyRule,
-} from "matrix-protection-suite";
-import { AccountRestriction } from "matrix-protection-suite-for-matrix-bot-sdk";
+} from "@the-draupnir-project/matrix-protection-suite";
+import { AccountRestriction } from "@the-draupnir-project/matrix-protection-suite-for-matrix-bot-sdk";
 
 export interface UserRestrictionCapability extends Capability {
   isUserRestricted(userID: StringUserID): Promise<Result<boolean>>;

--- a/apps/draupnir/src/protections/HomeserverUserPolicyApplication/UserRestrictionCapabilityRenderer.tsx
+++ b/apps/draupnir/src/protections/HomeserverUserPolicyApplication/UserRestrictionCapabilityRenderer.tsx
@@ -6,12 +6,12 @@ import {
   describeCapabilityRenderer,
   DescriptionMeta,
   LiteralPolicyRule,
-} from "matrix-protection-suite";
+} from "@the-draupnir-project/matrix-protection-suite";
 import { RendererMessageCollector } from "../../capabilities/RendererMessageCollector";
 import { UserRestrictionCapability } from "./UserRestrictionCapability";
 import { StringUserID } from "@the-draupnir-project/matrix-basic-types";
 import { isError, Result } from "@gnuxie/typescript-result";
-import { AccountRestriction } from "matrix-protection-suite-for-matrix-bot-sdk";
+import { AccountRestriction } from "@the-draupnir-project/matrix-protection-suite-for-matrix-bot-sdk";
 import { renderFailedSingularConsequence } from "@the-draupnir-project/mps-interface-adaptor";
 import {
   DeadDocumentJSX,

--- a/apps/draupnir/src/protections/HomeserverUserPolicyApplication/UserSuspensionCapability.ts
+++ b/apps/draupnir/src/protections/HomeserverUserPolicyApplication/UserSuspensionCapability.ts
@@ -5,7 +5,7 @@
 import {
   AccountRestriction,
   SynapseAdminClient,
-} from "matrix-protection-suite-for-matrix-bot-sdk";
+} from "@the-draupnir-project/matrix-protection-suite-for-matrix-bot-sdk";
 import { UserRestrictionCapability } from "./UserRestrictionCapability";
 import { UserRestrictionAuditLog } from "./UserRestrictionAuditLog";
 import { StringUserID } from "@the-draupnir-project/matrix-basic-types";
@@ -13,7 +13,7 @@ import {
   describeCapabilityProvider,
   LiteralPolicyRule,
   Logger,
-} from "matrix-protection-suite";
+} from "@the-draupnir-project/matrix-protection-suite";
 import { isError, Ok, Result, ResultError } from "@gnuxie/typescript-result";
 import { isUserAccountRestricted } from "./HomeserverUserPurgingDeactivate";
 import { Draupnir } from "../../Draupnir";

--- a/apps/draupnir/src/protections/HomeserverUserPolicyApplication/deactivateUser.ts
+++ b/apps/draupnir/src/protections/HomeserverUserPolicyApplication/deactivateUser.ts
@@ -4,11 +4,14 @@
 
 import { isError, Ok, Result } from "@gnuxie/typescript-result";
 import { StringUserID } from "@the-draupnir-project/matrix-basic-types";
-import { LiteralPolicyRule, Logger } from "matrix-protection-suite";
+import {
+  LiteralPolicyRule,
+  Logger,
+} from "@the-draupnir-project/matrix-protection-suite";
 import {
   AccountRestriction,
   SynapseAdminClient,
-} from "matrix-protection-suite-for-matrix-bot-sdk";
+} from "@the-draupnir-project/matrix-protection-suite-for-matrix-bot-sdk";
 import { UserRestrictionAuditLog } from "./UserRestrictionAuditLog";
 
 const log = new Logger("deactivateUser");

--- a/apps/draupnir/src/protections/InvalidEventProtection.tsx
+++ b/apps/draupnir/src/protections/InvalidEventProtection.tsx
@@ -19,7 +19,7 @@ import {
   RoomMessageSender,
   Task,
   UserConsequences,
-} from "matrix-protection-suite";
+} from "@the-draupnir-project/matrix-protection-suite";
 import { Draupnir } from "../Draupnir";
 import {
   MatrixRoomID,

--- a/apps/draupnir/src/protections/JoinWaveShortCircuit.tsx
+++ b/apps/draupnir/src/protections/JoinWaveShortCircuit.tsx
@@ -26,7 +26,7 @@ import {
   allocateProtection,
   describeProtection,
   isError,
-} from "matrix-protection-suite";
+} from "@the-draupnir-project/matrix-protection-suite";
 import { LogLevel } from "@vector-im/matrix-bot-sdk";
 import { Draupnir } from "../Draupnir";
 import { DraupnirProtection } from "./Protection";

--- a/apps/draupnir/src/protections/MembershipChangeProtection.tsx
+++ b/apps/draupnir/src/protections/MembershipChangeProtection.tsx
@@ -18,7 +18,7 @@ import {
   UserConsequences,
   allocateProtection,
   describeProtection,
-} from "matrix-protection-suite";
+} from "@the-draupnir-project/matrix-protection-suite";
 import { Draupnir } from "../Draupnir";
 import {
   MatrixRoomID,

--- a/apps/draupnir/src/protections/MentionLimitProtection.tsx
+++ b/apps/draupnir/src/protections/MentionLimitProtection.tsx
@@ -24,7 +24,7 @@ import {
   allocateProtection,
   describeProtection,
   isError,
-} from "matrix-protection-suite";
+} from "@the-draupnir-project/matrix-protection-suite";
 import { Draupnir } from "../Draupnir";
 import {
   MatrixRoomID,

--- a/apps/draupnir/src/protections/MessageIsMedia.ts
+++ b/apps/draupnir/src/protections/MessageIsMedia.ts
@@ -23,7 +23,7 @@ import {
   UnknownConfig,
   Value,
   describeProtection,
-} from "matrix-protection-suite";
+} from "@the-draupnir-project/matrix-protection-suite";
 import { Draupnir } from "../Draupnir";
 import {
   MatrixRoomID,

--- a/apps/draupnir/src/protections/MessageIsVoice.ts
+++ b/apps/draupnir/src/protections/MessageIsVoice.ts
@@ -23,7 +23,7 @@ import {
   UnknownConfig,
   Value,
   describeProtection,
-} from "matrix-protection-suite";
+} from "@the-draupnir-project/matrix-protection-suite";
 import { Draupnir } from "../Draupnir";
 import {
   MatrixRoomID,

--- a/apps/draupnir/src/protections/MissingProtectionPermissions.tsx
+++ b/apps/draupnir/src/protections/MissingProtectionPermissions.tsx
@@ -7,7 +7,7 @@ import {
   ProtectionPermissionsChange,
   RoomMessageSender,
   Task,
-} from "matrix-protection-suite";
+} from "@the-draupnir-project/matrix-protection-suite";
 import {
   renderRoomPill,
   sendMatrixEventsFromDeadDocument,

--- a/apps/draupnir/src/protections/NewJoinerProtection.ts
+++ b/apps/draupnir/src/protections/NewJoinerProtection.ts
@@ -19,7 +19,7 @@ import {
   UserConsequences,
   describeProtection,
   isError,
-} from "matrix-protection-suite";
+} from "@the-draupnir-project/matrix-protection-suite";
 import { Draupnir } from "../Draupnir";
 import { IConfig } from "../config";
 import { userServerName } from "@the-draupnir-project/matrix-basic-types";

--- a/apps/draupnir/src/protections/NotificationRoom/NotificationRoom.ts
+++ b/apps/draupnir/src/protections/NotificationRoom/NotificationRoom.ts
@@ -18,7 +18,7 @@ import {
   RoomInviter,
   RoomMembershipManager,
   RoomStateEventSender,
-} from "matrix-protection-suite";
+} from "@the-draupnir-project/matrix-protection-suite";
 import { Draupnir } from "../../Draupnir";
 
 export type SettingChangeAndProtectionEnableCB<

--- a/apps/draupnir/src/protections/PolicyChangeNotification.tsx
+++ b/apps/draupnir/src/protections/PolicyChangeNotification.tsx
@@ -26,7 +26,7 @@ import {
   StringRoomIDSchema,
   describeProtection,
   isError,
-} from "matrix-protection-suite";
+} from "@the-draupnir-project/matrix-protection-suite";
 import { DraupnirProtection } from "./Protection";
 import { Draupnir } from "../Draupnir";
 import {

--- a/apps/draupnir/src/protections/ProtectedRooms/ProtectJoinedRooms.tsx
+++ b/apps/draupnir/src/protections/ProtectedRooms/ProtectJoinedRooms.tsx
@@ -20,7 +20,7 @@ import {
   RoomSetResultBuilder,
   StandardBatcher,
   Task,
-} from "matrix-protection-suite";
+} from "@the-draupnir-project/matrix-protection-suite";
 import {
   renderRoomSetResult,
   sendMatrixEventsFromDeadDocument,

--- a/apps/draupnir/src/protections/ProtectedRooms/ProtectReplacementRooms.tsx
+++ b/apps/draupnir/src/protections/ProtectedRooms/ProtectReplacementRooms.tsx
@@ -27,7 +27,7 @@ import {
   Task,
   TombstoneEvent,
   Value,
-} from "matrix-protection-suite";
+} from "@the-draupnir-project/matrix-protection-suite";
 import { DeadDocumentJSX } from "@the-draupnir-project/interface-manager";
 
 const log = new Logger("ProtectReplacementRooms");

--- a/apps/draupnir/src/protections/ProtectedRooms/RoomsSetBehaviourProtection.tsx
+++ b/apps/draupnir/src/protections/ProtectedRooms/RoomsSetBehaviourProtection.tsx
@@ -16,7 +16,7 @@ import {
   RoomStateRevision,
   StateChange,
   UnknownConfig,
-} from "matrix-protection-suite";
+} from "@the-draupnir-project/matrix-protection-suite";
 import { DraupnirProtection } from "../Protection";
 import { Draupnir } from "../../Draupnir";
 import { Ok, Result } from "@gnuxie/typescript-result";

--- a/apps/draupnir/src/protections/ProtectedRooms/UnprotectPartedRooms.tsx
+++ b/apps/draupnir/src/protections/ProtectedRooms/UnprotectPartedRooms.tsx
@@ -14,7 +14,7 @@ import {
   ProtectedRoomsManager,
   RoomMessageSender,
   Task,
-} from "matrix-protection-suite";
+} from "@the-draupnir-project/matrix-protection-suite";
 import {
   renderMentionPill,
   renderRoomPill,

--- a/apps/draupnir/src/protections/ProtectedRooms/WatchReplacementPolicyRooms.tsx
+++ b/apps/draupnir/src/protections/ProtectedRooms/WatchReplacementPolicyRooms.tsx
@@ -13,6 +13,7 @@ import {
   RoomEvent,
   RoomJoiner,
   RoomMessageSender,
+  RoomReactionSender,
   RoomStateManager,
   RoomStateRevision,
   RoomVersionMirror,
@@ -42,7 +43,6 @@ import {
   renderErrorDetails,
   ReactionListener,
 } from "@the-draupnir-project/mps-interface-adaptor";
-import { RoomReactionSender } from "matrix-protection-suite/dist/Client/RoomReactionSender";
 
 const log = new Logger("WatchReplacementPolicyRooms");
 

--- a/apps/draupnir/src/protections/ProtectedRooms/WatchReplacementPolicyRooms.tsx
+++ b/apps/draupnir/src/protections/ProtectedRooms/WatchReplacementPolicyRooms.tsx
@@ -23,7 +23,7 @@ import {
   Value,
   WatchedPolicyRoom,
   WatchedPolicyRooms,
-} from "matrix-protection-suite";
+} from "@the-draupnir-project/matrix-protection-suite";
 import { renderPolicyList } from "../../commands/StatusCommand";
 import { DeadDocumentJSX } from "@the-draupnir-project/interface-manager";
 import {

--- a/apps/draupnir/src/protections/ProtectedRoomsSetRenderers.tsx
+++ b/apps/draupnir/src/protections/ProtectedRoomsSetRenderers.tsx
@@ -13,7 +13,7 @@ import {
   ProtectionDescription,
   RoomMessageSender,
   Task,
-} from "matrix-protection-suite";
+} from "@the-draupnir-project/matrix-protection-suite";
 import { StringRoomID } from "@the-draupnir-project/matrix-basic-types";
 import { sendMatrixEventsFromDeadDocument } from "@the-draupnir-project/mps-interface-adaptor";
 import { DeadDocumentJSX } from "@the-draupnir-project/interface-manager";

--- a/apps/draupnir/src/protections/Protection.ts
+++ b/apps/draupnir/src/protections/Protection.ts
@@ -8,7 +8,7 @@
 // https://github.com/matrix-org/mjolnir
 // </text>
 
-import { Protection } from "matrix-protection-suite";
+import { Protection } from "@the-draupnir-project/matrix-protection-suite";
 
 export interface DraupnirProtection<
   TProtectionDescription,

--- a/apps/draupnir/src/protections/RedactionSynchronisation.ts
+++ b/apps/draupnir/src/protections/RedactionSynchronisation.ts
@@ -33,7 +33,7 @@ import {
   describeCapabilityProvider,
   describeCapabilityRenderer,
   describeProtection,
-} from "matrix-protection-suite";
+} from "@the-draupnir-project/matrix-protection-suite";
 import { Draupnir } from "../Draupnir";
 import {
   MatrixGlob,

--- a/apps/draupnir/src/protections/RoomTakedown/DiscoveredRoomStore.ts
+++ b/apps/draupnir/src/protections/RoomTakedown/DiscoveredRoomStore.ts
@@ -11,7 +11,7 @@ import {
   Logger,
   RoomBasicDetails,
   SHA256HashStore,
-} from "matrix-protection-suite";
+} from "@the-draupnir-project/matrix-protection-suite";
 import { RoomDetailsProvider } from "../../capabilities/RoomTakedownCapability";
 import { RoomDiscovery } from "./RoomDiscovery";
 import EventEmitter from "events";

--- a/apps/draupnir/src/protections/RoomTakedown/RoomAuditLog.ts
+++ b/apps/draupnir/src/protections/RoomTakedown/RoomAuditLog.ts
@@ -7,7 +7,10 @@ import {
   StringEventID,
   StringRoomID,
 } from "@the-draupnir-project/matrix-basic-types";
-import { LiteralPolicyRule, RoomBasicDetails } from "matrix-protection-suite";
+import {
+  LiteralPolicyRule,
+  RoomBasicDetails,
+} from "@the-draupnir-project/matrix-protection-suite";
 
 export type RoomTakedownDetails = Omit<RoomBasicDetails, "avatar"> & {
   policy_id: StringEventID;

--- a/apps/draupnir/src/protections/RoomTakedown/RoomDiscovery.ts
+++ b/apps/draupnir/src/protections/RoomTakedown/RoomDiscovery.ts
@@ -2,7 +2,10 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-import { PolicyRuleChange, RoomBasicDetails } from "matrix-protection-suite";
+import {
+  PolicyRuleChange,
+  RoomBasicDetails,
+} from "@the-draupnir-project/matrix-protection-suite";
 import { RoomToCheck } from "./DiscoveredRoomStore";
 import { Result } from "@gnuxie/typescript-result";
 import { StringRoomID } from "@the-draupnir-project/matrix-basic-types";

--- a/apps/draupnir/src/protections/RoomTakedown/RoomDiscoveryRenderer.tsx
+++ b/apps/draupnir/src/protections/RoomTakedown/RoomDiscoveryRenderer.tsx
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { DocumentNode } from "@the-draupnir-project/interface-manager";
-import { RoomBasicDetails } from "matrix-protection-suite";
+import { RoomBasicDetails } from "@the-draupnir-project/matrix-protection-suite";
 import { DeadDocumentJSX } from "@the-draupnir-project/interface-manager";
 
 export function renderDiscoveredRoom(details: RoomBasicDetails): DocumentNode {

--- a/apps/draupnir/src/protections/RoomTakedown/RoomTakedown.ts
+++ b/apps/draupnir/src/protections/RoomTakedown/RoomTakedown.ts
@@ -12,7 +12,7 @@ import {
   PolicyRuleMatchType,
   PolicyRuleType,
   Recommendation,
-} from "matrix-protection-suite";
+} from "@the-draupnir-project/matrix-protection-suite";
 import { RoomAuditLog } from "./RoomAuditLog";
 import { isError, Ok, Result } from "@gnuxie/typescript-result";
 import { RoomTakedownCapability } from "../../capabilities/RoomTakedownCapability";

--- a/apps/draupnir/src/protections/RoomTakedown/RoomTakedownProtection.ts
+++ b/apps/draupnir/src/protections/RoomTakedown/RoomTakedownProtection.ts
@@ -7,6 +7,7 @@ import {
   ActionResult,
   allocateProtection,
   describeProtection,
+  EDStatic,
   Logger,
   OwnLifetime,
   PolicyListRevision,
@@ -40,7 +41,6 @@ import {
   sendMatrixEventsFromDeadDocument,
 } from "@the-draupnir-project/mps-interface-adaptor";
 import { Type } from "@sinclair/typebox";
-import { EDStatic } from "matrix-protection-suite/dist/Interface/Static";
 import { renderDiscoveredRoom } from "./RoomDiscoveryRenderer";
 import { NotificationRoomCreator } from "../NotificationRoom/NotificationRoom";
 import { MatrixGlob } from "@vector-im/matrix-bot-sdk";

--- a/apps/draupnir/src/protections/RoomTakedown/RoomTakedownProtection.ts
+++ b/apps/draupnir/src/protections/RoomTakedown/RoomTakedownProtection.ts
@@ -19,7 +19,7 @@ import {
   SHA256HashStore,
   StringRoomIDSchema,
   Task,
-} from "matrix-protection-suite";
+} from "@the-draupnir-project/matrix-protection-suite";
 import { RoomTakedownCapability } from "../../capabilities/RoomTakedownCapability";
 import { Draupnir } from "../../Draupnir";
 import { StandardRoomTakedown } from "./RoomTakedown";

--- a/apps/draupnir/src/protections/RoomTakedown/SqliteRoomAuditLog.ts
+++ b/apps/draupnir/src/protections/RoomTakedown/SqliteRoomAuditLog.ts
@@ -15,7 +15,7 @@ import {
   Logger,
   PolicyRuleType,
   RoomBasicDetails,
-} from "matrix-protection-suite";
+} from "@the-draupnir-project/matrix-protection-suite";
 import {
   BetterSqliteOptions,
   BetterSqliteStore,

--- a/apps/draupnir/src/protections/RoomTakedown/SynapseHTTPAntispamRoomExplorer.ts
+++ b/apps/draupnir/src/protections/RoomTakedown/SynapseHTTPAntispamRoomExplorer.ts
@@ -8,7 +8,7 @@ import {
   Logger,
   PolicyRuleChange,
   StandardBatcher,
-} from "matrix-protection-suite";
+} from "@the-draupnir-project/matrix-protection-suite";
 import { CheckEventForSpamRequestBody } from "../../webapis/SynapseHTTPAntispam/CheckEventForSpamEndpoint";
 import { SynapseHttpAntispam } from "../../webapis/SynapseHTTPAntispam/SynapseHttpAntispam";
 import { StringRoomID } from "@the-draupnir-project/matrix-basic-types";

--- a/apps/draupnir/src/protections/RoomTakedown/SynapseRoomListRoomExplorerer.ts
+++ b/apps/draupnir/src/protections/RoomTakedown/SynapseRoomListRoomExplorerer.ts
@@ -12,9 +12,11 @@ import {
   PolicyRuleChangeType,
   StandardTimedGate,
 } from "@the-draupnir-project/matrix-protection-suite";
-import { SynapseAdminClient } from "@the-draupnir-project/matrix-protection-suite-for-matrix-bot-sdk";
+import {
+  RoomListResponse,
+  SynapseAdminClient,
+} from "@the-draupnir-project/matrix-protection-suite-for-matrix-bot-sdk";
 import { isError, Result } from "@gnuxie/typescript-result";
-import { RoomListResponse } from "matrix-protection-suite-for-matrix-bot-sdk/dist/SynapseAdmin/RoomListEndpoint";
 
 const log = new Logger("SynapseRoomListExplorer");
 

--- a/apps/draupnir/src/protections/RoomTakedown/SynapseRoomListRoomExplorerer.ts
+++ b/apps/draupnir/src/protections/RoomTakedown/SynapseRoomListRoomExplorerer.ts
@@ -11,8 +11,8 @@ import {
   PolicyRuleChange,
   PolicyRuleChangeType,
   StandardTimedGate,
-} from "matrix-protection-suite";
-import { SynapseAdminClient } from "matrix-protection-suite-for-matrix-bot-sdk";
+} from "@the-draupnir-project/matrix-protection-suite";
+import { SynapseAdminClient } from "@the-draupnir-project/matrix-protection-suite-for-matrix-bot-sdk";
 import { isError, Result } from "@gnuxie/typescript-result";
 import { RoomListResponse } from "matrix-protection-suite-for-matrix-bot-sdk/dist/SynapseAdmin/RoomListEndpoint";
 

--- a/apps/draupnir/src/protections/TrustedReporters.ts
+++ b/apps/draupnir/src/protections/TrustedReporters.ts
@@ -24,7 +24,7 @@ import {
   UserConsequences,
   describeProtection,
   isError,
-} from "matrix-protection-suite";
+} from "@the-draupnir-project/matrix-protection-suite";
 import { Draupnir } from "../Draupnir";
 import {
   StringUserID,

--- a/apps/draupnir/src/protections/WordList.ts
+++ b/apps/draupnir/src/protections/WordList.ts
@@ -30,14 +30,14 @@ import {
   UserConsequences,
   describeProtection,
   isError,
-} from "matrix-protection-suite";
+} from "@the-draupnir-project/matrix-protection-suite";
 import { Draupnir } from "../Draupnir";
 import {
   StringUserID,
   StringRoomID,
   MatrixRoomID,
 } from "@the-draupnir-project/matrix-basic-types";
-import { resultifyBotSDKRequestError } from "matrix-protection-suite-for-matrix-bot-sdk";
+import { resultifyBotSDKRequestError } from "@the-draupnir-project/matrix-protection-suite-for-matrix-bot-sdk";
 
 const log = new Logger("WordList");
 

--- a/apps/draupnir/src/protections/invitation/JoinRoomsOnInviteProtection.tsx
+++ b/apps/draupnir/src/protections/invitation/JoinRoomsOnInviteProtection.tsx
@@ -25,7 +25,7 @@ import {
   allocateProtection,
   describeProtection,
   isError,
-} from "matrix-protection-suite";
+} from "@the-draupnir-project/matrix-protection-suite";
 import { Draupnir } from "../../Draupnir";
 import { DraupnirProtection } from "../Protection";
 import { isInvitationForUser, isSenderJoinedInRevision } from "./inviteCore";

--- a/apps/draupnir/src/protections/invitation/ProtectRoomsOnInvite.tsx
+++ b/apps/draupnir/src/protections/invitation/ProtectRoomsOnInvite.tsx
@@ -18,7 +18,7 @@ import {
   Value,
   isError,
   RoomIDPermalinkSchema,
-} from "matrix-protection-suite";
+} from "@the-draupnir-project/matrix-protection-suite";
 import {
   renderActionResultToEvent,
   renderMentionPill,

--- a/apps/draupnir/src/protections/invitation/WatchRoomsOnInvite.tsx
+++ b/apps/draupnir/src/protections/invitation/WatchRoomsOnInvite.tsx
@@ -21,7 +21,7 @@ import {
   Task,
   Value,
   isError,
-} from "matrix-protection-suite";
+} from "@the-draupnir-project/matrix-protection-suite";
 import { Draupnir } from "../../Draupnir";
 import {
   renderActionResultToEvent,

--- a/apps/draupnir/src/protections/invitation/inviteCore.ts
+++ b/apps/draupnir/src/protections/invitation/inviteCore.ts
@@ -7,7 +7,7 @@ import {
   Membership,
   MembershipEvent,
   RoomMembershipRevision,
-} from "matrix-protection-suite";
+} from "@the-draupnir-project/matrix-protection-suite";
 
 export function isInvitationForUser(
   event: MembershipEvent,

--- a/apps/draupnir/src/queues/EventRedactionQueue.ts
+++ b/apps/draupnir/src/queues/EventRedactionQueue.ts
@@ -11,13 +11,13 @@
 import { LogLevel } from "@vector-im/matrix-bot-sdk";
 import { redactUserMessagesIn } from "../utils";
 import ManagementRoomOutput from "../managementroom/ManagementRoomOutput";
-import { MatrixSendClient } from "matrix-protection-suite-for-matrix-bot-sdk";
+import { MatrixSendClient } from "@the-draupnir-project/matrix-protection-suite-for-matrix-bot-sdk";
 import {
   ActionExceptionKind,
   assertThrowableIsError,
   RoomUpdateError,
   RoomUpdateException,
-} from "matrix-protection-suite";
+} from "@the-draupnir-project/matrix-protection-suite";
 import {
   StringRoomID,
   StringUserID,

--- a/apps/draupnir/src/queues/ProtectedRoomActivityTracker.ts
+++ b/apps/draupnir/src/queues/ProtectedRoomActivityTracker.ts
@@ -9,7 +9,7 @@
 // </text>
 
 import { StringRoomID } from "@the-draupnir-project/matrix-basic-types";
-import { RoomEvent } from "matrix-protection-suite";
+import { RoomEvent } from "@the-draupnir-project/matrix-protection-suite";
 
 /**
  * Used to keep track of protected rooms so they are always ordered for activity.

--- a/apps/draupnir/src/queues/TimelineRedactionQueue.ts
+++ b/apps/draupnir/src/queues/TimelineRedactionQueue.ts
@@ -14,7 +14,7 @@ import {
   Logger,
   RoomEventRedacter,
   RoomMessages,
-} from "matrix-protection-suite";
+} from "@the-draupnir-project/matrix-protection-suite";
 
 const log = new Logger("TimelineRedactionQueue");
 

--- a/apps/draupnir/src/queues/UnlistedUserRedactionQueue.ts
+++ b/apps/draupnir/src/queues/UnlistedUserRedactionQueue.ts
@@ -8,7 +8,7 @@
 // https://github.com/matrix-org/mjolnir
 // </text>
 import { LogLevel, LogService } from "@vector-im/matrix-bot-sdk";
-import { RoomEvent } from "matrix-protection-suite";
+import { RoomEvent } from "@the-draupnir-project/matrix-protection-suite";
 import { Draupnir } from "../Draupnir";
 import {
   StringUserID,

--- a/apps/draupnir/src/report/ReportManager.ts
+++ b/apps/draupnir/src/report/ReportManager.ts
@@ -11,7 +11,7 @@
 import { PowerLevelAction } from "@vector-im/matrix-bot-sdk";
 import { LogService, UserID } from "@vector-im/matrix-bot-sdk";
 import { htmlToText } from "html-to-text";
-import { extractRawRoomEvent } from "matrix-protection-suite-for-matrix-bot-sdk";
+import { extractRawRoomEvent } from "@the-draupnir-project/matrix-protection-suite-for-matrix-bot-sdk";
 import { htmlEscape } from "../utils";
 import { JSDOM } from "jsdom";
 import { Draupnir } from "../Draupnir";
@@ -24,7 +24,7 @@ import {
   TextMessageContent,
   Value,
   isError,
-} from "matrix-protection-suite";
+} from "@the-draupnir-project/matrix-protection-suite";
 import {
   StringRoomID,
   StringUserID,

--- a/apps/draupnir/src/report/ReportPoller.ts
+++ b/apps/draupnir/src/report/ReportPoller.ts
@@ -12,7 +12,7 @@ import {
   MatrixSendClient,
   resultifyBotSDKRequestErrorWith404AsUndefined,
   SynapseAdminClient,
-} from "matrix-protection-suite-for-matrix-bot-sdk";
+} from "@the-draupnir-project/matrix-protection-suite-for-matrix-bot-sdk";
 import { ReportManager } from "./ReportManager";
 import { LogLevel } from "@vector-im/matrix-bot-sdk";
 import ManagementRoomOutput from "../managementroom/ManagementRoomOutput";
@@ -25,7 +25,7 @@ import {
   Task,
   assertThrowableIsError,
   isError,
-} from "matrix-protection-suite";
+} from "@the-draupnir-project/matrix-protection-suite";
 
 /**
  * Synapse will tell us where we last got to on polling reports, so we need

--- a/apps/draupnir/src/safemode/DraupnirSafeMode.ts
+++ b/apps/draupnir/src/safemode/DraupnirSafeMode.ts
@@ -8,13 +8,13 @@ import {
   EventReport,
   RoomEvent,
   Task,
-} from "matrix-protection-suite";
+} from "@the-draupnir-project/matrix-protection-suite";
 import {
   StringUserID,
   StringRoomID,
   MatrixRoomID,
 } from "@the-draupnir-project/matrix-basic-types";
-import { MatrixSendClient } from "matrix-protection-suite-for-matrix-bot-sdk";
+import { MatrixSendClient } from "@the-draupnir-project/matrix-protection-suite-for-matrix-bot-sdk";
 import { IConfig } from "../config";
 import { SafeModeCause } from "./SafeModeCause";
 import {

--- a/apps/draupnir/src/safemode/ManagementRoom.ts
+++ b/apps/draupnir/src/safemode/ManagementRoom.ts
@@ -21,8 +21,8 @@ import {
   Task,
   TextMessageContent,
   Value,
-} from "matrix-protection-suite";
-import { MatrixSendClient } from "matrix-protection-suite-for-matrix-bot-sdk";
+} from "@the-draupnir-project/matrix-protection-suite";
+import { MatrixSendClient } from "@the-draupnir-project/matrix-protection-suite-for-matrix-bot-sdk";
 import { MatrixEventContext } from "@the-draupnir-project/mps-interface-adaptor";
 
 const log = new Logger("ManagementRoom");

--- a/apps/draupnir/src/safemode/PersistentConfigEditor.ts
+++ b/apps/draupnir/src/safemode/PersistentConfigEditor.ts
@@ -15,11 +15,11 @@ import {
   MjolnirProtectedRoomsDescription,
   PersistentConfigData,
   StandardPersistentConfigData,
-} from "matrix-protection-suite";
+} from "@the-draupnir-project/matrix-protection-suite";
 import {
   BotSDKAccountDataConfigBackend,
   MatrixSendClient,
-} from "matrix-protection-suite-for-matrix-bot-sdk";
+} from "@the-draupnir-project/matrix-protection-suite-for-matrix-bot-sdk";
 import { SafeModeCause, SafeModeReason } from "./SafeModeCause";
 
 export type PersistentConfigStatus = {

--- a/apps/draupnir/src/safemode/PersistentConfigRenderer.tsx
+++ b/apps/draupnir/src/safemode/PersistentConfigRenderer.tsx
@@ -17,7 +17,7 @@ import {
   ConfigPropertyDescription,
   ConfigPropertyError,
   ConfigPropertyUseError,
-} from "matrix-protection-suite";
+} from "@the-draupnir-project/matrix-protection-suite";
 import {
   renderMentionPill,
   renderRoomPill,

--- a/apps/draupnir/src/safemode/RecoveryOptions.tsx
+++ b/apps/draupnir/src/safemode/RecoveryOptions.tsx
@@ -6,7 +6,7 @@ import {
   DeadDocumentJSX,
   DocumentNode,
 } from "@the-draupnir-project/interface-manager";
-import { ConfigRecoverableError } from "matrix-protection-suite";
+import { ConfigRecoverableError } from "@the-draupnir-project/matrix-protection-suite";
 import { SafeModeCause, SafeModeReason } from "./SafeModeCause";
 import { MatrixReactionHandler } from "@the-draupnir-project/mps-interface-adaptor";
 

--- a/apps/draupnir/src/safemode/commands/HelpCommand.tsx
+++ b/apps/draupnir/src/safemode/commands/HelpCommand.tsx
@@ -12,7 +12,7 @@ import {
   TopPresentationSchema,
   CommandTable,
 } from "@the-draupnir-project/interface-manager";
-import { Ok } from "matrix-protection-suite";
+import { Ok } from "@the-draupnir-project/matrix-protection-suite";
 import { renderTableHelp } from "@the-draupnir-project/mps-interface-adaptor";
 import { safeModeHeader } from "./StatusCommand";
 import { DOCUMENTATION_URL } from "../../config";

--- a/apps/draupnir/src/safemode/commands/RecoverCommand.tsx
+++ b/apps/draupnir/src/safemode/commands/RecoverCommand.tsx
@@ -16,7 +16,7 @@ import {
   ConfigRecoverableError,
   ConfigRecoveryOption,
   RoomEvent,
-} from "matrix-protection-suite";
+} from "@the-draupnir-project/matrix-protection-suite";
 import { SafeModeInterfaceAdaptor } from "./SafeModeAdaptor";
 import {
   PersistentConfigStatus,

--- a/apps/draupnir/src/safemode/commands/StatusCommand.tsx
+++ b/apps/draupnir/src/safemode/commands/StatusCommand.tsx
@@ -8,7 +8,11 @@ import {
   DocumentNode,
   describeCommand,
 } from "@the-draupnir-project/interface-manager";
-import { ActionException, Ok, isError } from "matrix-protection-suite";
+import {
+  ActionException,
+  Ok,
+  isError,
+} from "@the-draupnir-project/matrix-protection-suite";
 import { SafeModeDraupnir } from "../DraupnirSafeMode";
 import { SafeModeCause, SafeModeReason } from "../SafeModeCause";
 import {

--- a/apps/draupnir/src/utils.ts
+++ b/apps/draupnir/src/utils.ts
@@ -21,8 +21,11 @@ import * as Sentry from "@sentry/node";
 import ManagementRoomOutput from "./managementroom/ManagementRoomOutput";
 import { IConfig } from "./config";
 import { Gauge } from "prom-client";
-import { MatrixSendClient } from "matrix-protection-suite-for-matrix-bot-sdk";
-import { Logger, RoomEvent } from "matrix-protection-suite";
+import { MatrixSendClient } from "@the-draupnir-project/matrix-protection-suite-for-matrix-bot-sdk";
+import {
+  Logger,
+  RoomEvent,
+} from "@the-draupnir-project/matrix-protection-suite";
 
 const log = new Logger("utils");
 

--- a/apps/draupnir/src/webapis/SynapseHTTPAntispam/CheckEventForSpamEndpoint.ts
+++ b/apps/draupnir/src/webapis/SynapseHTTPAntispam/CheckEventForSpamEndpoint.ts
@@ -10,7 +10,7 @@ import {
   RoomEvent,
   Task,
   Value,
-} from "matrix-protection-suite";
+} from "@the-draupnir-project/matrix-protection-suite";
 import { SpamCheckEndpointPluginManager } from "./SpamCheckEndpointPluginManager";
 import { Request, Response } from "express";
 

--- a/apps/draupnir/src/webapis/SynapseHTTPAntispam/PingEndpoint.ts
+++ b/apps/draupnir/src/webapis/SynapseHTTPAntispam/PingEndpoint.ts
@@ -9,7 +9,11 @@
 
 import { Type } from "@sinclair/typebox";
 import { Request, Response } from "express";
-import { isError, Logger, Value } from "matrix-protection-suite";
+import {
+  isError,
+  Logger,
+  Value,
+} from "@the-draupnir-project/matrix-protection-suite";
 
 const log = new Logger("PingEndpoint");
 

--- a/apps/draupnir/src/webapis/SynapseHTTPAntispam/SpamCheckEndpointPluginManager.ts
+++ b/apps/draupnir/src/webapis/SynapseHTTPAntispam/SpamCheckEndpointPluginManager.ts
@@ -2,7 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-import { Logger, Task } from "matrix-protection-suite";
+import { Logger, Task } from "@the-draupnir-project/matrix-protection-suite";
 
 type BlockingResponse =
   | "NOT_SPAM"

--- a/apps/draupnir/src/webapis/SynapseHTTPAntispam/UserMayInviteEndpoint.ts
+++ b/apps/draupnir/src/webapis/SynapseHTTPAntispam/UserMayInviteEndpoint.ts
@@ -12,7 +12,7 @@ import {
   StringUserIDSchema,
   Task,
   Value,
-} from "matrix-protection-suite";
+} from "@the-draupnir-project/matrix-protection-suite";
 import { Type } from "@sinclair/typebox";
 
 // for check_event_for_spam we will leave the event as unparsed

--- a/apps/draupnir/src/webapis/SynapseHTTPAntispam/UserMayJoinRoomEndpoint.ts
+++ b/apps/draupnir/src/webapis/SynapseHTTPAntispam/UserMayJoinRoomEndpoint.ts
@@ -11,7 +11,7 @@ import {
   StringUserIDSchema,
   Task,
   Value,
-} from "matrix-protection-suite";
+} from "@the-draupnir-project/matrix-protection-suite";
 import { SpamCheckEndpointPluginManager } from "./SpamCheckEndpointPluginManager";
 import { Request, Response } from "express";
 

--- a/apps/draupnir/src/webapis/WebAPIs.ts
+++ b/apps/draupnir/src/webapis/WebAPIs.ts
@@ -19,8 +19,12 @@ import {
   isStringRoomID,
   isStringEventID,
 } from "@the-draupnir-project/matrix-basic-types";
-import { Logger, RoomEvent, Task } from "matrix-protection-suite";
-import { extractRawRoomEvent } from "matrix-protection-suite-for-matrix-bot-sdk";
+import {
+  Logger,
+  RoomEvent,
+  Task,
+} from "@the-draupnir-project/matrix-protection-suite";
+import { extractRawRoomEvent } from "@the-draupnir-project/matrix-protection-suite-for-matrix-bot-sdk";
 import { SynapseHttpAntispam } from "./SynapseHTTPAntispam/SynapseHttpAntispam";
 import { jsonReviver } from "../utils";
 

--- a/apps/draupnir/test/appservice/integration/listUnstartedDraupnirTest.ts
+++ b/apps/draupnir/test/appservice/integration/listUnstartedDraupnirTest.ts
@@ -5,7 +5,7 @@
 import expect from "expect";
 import { MjolnirAppService } from "../../../src/appservice/AppService";
 import { setupHarness } from "../utils/harness";
-import { isError } from "matrix-protection-suite";
+import { isError } from "@the-draupnir-project/matrix-protection-suite";
 import { StringUserID } from "@the-draupnir-project/matrix-basic-types";
 
 interface Context extends Mocha.Context {

--- a/apps/draupnir/test/appservice/integration/provisionTest.ts
+++ b/apps/draupnir/test/appservice/integration/provisionTest.ts
@@ -14,7 +14,7 @@ import { newTestUser } from "../../integration/clientHelper";
 import { getFirstReply } from "../../integration/commands/commandUtils";
 import { MatrixClient } from "@vector-im/matrix-bot-sdk";
 import { MjolnirAppService } from "../../../src/appservice/AppService";
-import { isOk } from "matrix-protection-suite";
+import { isOk } from "@the-draupnir-project/matrix-protection-suite";
 import { StringUserID } from "@the-draupnir-project/matrix-basic-types";
 
 interface Context extends Mocha.Context {

--- a/apps/draupnir/test/appservice/integration/versionAndBranchDraupnirTest.ts
+++ b/apps/draupnir/test/appservice/integration/versionAndBranchDraupnirTest.ts
@@ -5,7 +5,7 @@
 import expect from "expect";
 import { MjolnirAppService } from "../../../src/appservice/AppService";
 import { setupHarness } from "../utils/harness";
-import { isError } from "matrix-protection-suite";
+import { isError } from "@the-draupnir-project/matrix-protection-suite";
 import { StringUserID } from "@the-draupnir-project/matrix-basic-types";
 
 interface Context extends Mocha.Context {

--- a/apps/draupnir/test/appservice/utils/harness.ts
+++ b/apps/draupnir/test/appservice/utils/harness.ts
@@ -19,7 +19,7 @@ import {
 } from "../../../src/appservice/config/config";
 import { newTestUser } from "../../integration/clientHelper";
 import { CreateEvent, MatrixClient } from "@vector-im/matrix-bot-sdk";
-import { POLICY_ROOM_TYPE_VARIANTS } from "matrix-protection-suite";
+import { POLICY_ROOM_TYPE_VARIANTS } from "@the-draupnir-project/matrix-protection-suite";
 import { isStringRoomAlias } from "@the-draupnir-project/matrix-basic-types";
 
 export function readTestConfig(): AppserviceConfig {

--- a/apps/draupnir/test/integration/abuseReportTest.ts
+++ b/apps/draupnir/test/integration/abuseReportTest.ts
@@ -20,12 +20,12 @@ import {
   RoomEvent,
   RoomMessage,
   Value,
-} from "matrix-protection-suite";
+} from "@the-draupnir-project/matrix-protection-suite";
 import { StringEventID } from "@the-draupnir-project/matrix-basic-types";
 import {
   extractRawRoomEvent,
   resultifyBotSDKRequestError,
-} from "matrix-protection-suite-for-matrix-bot-sdk";
+} from "@the-draupnir-project/matrix-protection-suite-for-matrix-bot-sdk";
 
 /**
  * Test the ability to turn abuse reports into room messages.

--- a/apps/draupnir/test/integration/banPropagationTest.ts
+++ b/apps/draupnir/test/integration/banPropagationTest.ts
@@ -14,7 +14,7 @@ import {
   RoomMessage,
   Value,
   findProtection,
-} from "matrix-protection-suite";
+} from "@the-draupnir-project/matrix-protection-suite";
 import {
   MatrixRoomReference,
   StringRoomID,

--- a/apps/draupnir/test/integration/clientHelper.ts
+++ b/apps/draupnir/test/integration/clientHelper.ts
@@ -21,7 +21,7 @@ import {
   NoticeMessageContent,
   RoomMessage,
   Value,
-} from "matrix-protection-suite";
+} from "@the-draupnir-project/matrix-protection-suite";
 import { RequestFunction } from "../../src/utils";
 
 const REGISTRATION_ATTEMPTS = 10;

--- a/apps/draupnir/test/integration/commands/commandUtils.ts
+++ b/apps/draupnir/test/integration/commands/commandUtils.ts
@@ -14,7 +14,7 @@ import * as crypto from "crypto";
 import {
   MatrixSendClient,
   SafeMatrixEmitter,
-} from "matrix-protection-suite-for-matrix-bot-sdk";
+} from "@the-draupnir-project/matrix-protection-suite-for-matrix-bot-sdk";
 import {
   NoticeMessageContent,
   ReactionEvent,
@@ -24,7 +24,7 @@ import {
   StringEventIDSchema,
   ReactionContent,
   hasOwn,
-} from "matrix-protection-suite";
+} from "@the-draupnir-project/matrix-protection-suite";
 import { Type } from "@sinclair/typebox";
 import { Draupnir } from "../../../src/Draupnir";
 import {

--- a/apps/draupnir/test/integration/commands/hijackRoomCommandTest.ts
+++ b/apps/draupnir/test/integration/commands/hijackRoomCommandTest.ts
@@ -12,7 +12,7 @@ import { strict as assert } from "assert";
 import { newTestUser } from "../clientHelper";
 import { getFirstReaction } from "./commandUtils";
 import { DraupnirTestContext, draupnirSafeEmitter } from "../mjolnirSetupUtils";
-import { PowerLevelsEventContent } from "matrix-protection-suite";
+import { PowerLevelsEventContent } from "@the-draupnir-project/matrix-protection-suite";
 
 // Breaks with this test.
 describe("Test: The make admin command", function () {

--- a/apps/draupnir/test/integration/commands/recoverCommandDetail.ts
+++ b/apps/draupnir/test/integration/commands/recoverCommandDetail.ts
@@ -6,6 +6,8 @@ import {
   MJOLNIR_PROTECTED_ROOMS_EVENT_TYPE,
   MJOLNIR_WATCHED_POLICY_ROOMS_EVENT_TYPE,
   MjolnirEnabledProtectionsEventType,
+  MjolnirPolicyRoomsEncodedShape,
+  MjolnirProtectedRoomsEncodedShape,
   MjolnirProtectedRoomsEvent,
 } from "@the-draupnir-project/matrix-protection-suite";
 import { Draupnir } from "../../../src/Draupnir";
@@ -18,8 +20,6 @@ import { isOk } from "@gnuxie/typescript-result";
 import { SafeModeDraupnir } from "../../../src/safemode/DraupnirSafeMode";
 import { DraupnirRestartError } from "../../../src/safemode/SafeModeToggle";
 import { MatrixSendClient } from "@the-draupnir-project/matrix-protection-suite-for-matrix-bot-sdk";
-import { MjolnirPolicyRoomsEncodedShape } from "matrix-protection-suite/dist/Protection/PolicyListConfig/MjolnirPolicyRoomsDescription";
-import { MjolnirProtectedRoomsEncodedShape } from "matrix-protection-suite/dist/Protection/ProtectedRoomsConfig/MjolnirProtectedRoomsDescription";
 
 async function clobberProtectedRooms(client: MatrixSendClient): Promise<void> {
   const existingAccountData =

--- a/apps/draupnir/test/integration/commands/recoverCommandDetail.ts
+++ b/apps/draupnir/test/integration/commands/recoverCommandDetail.ts
@@ -7,7 +7,7 @@ import {
   MJOLNIR_WATCHED_POLICY_ROOMS_EVENT_TYPE,
   MjolnirEnabledProtectionsEventType,
   MjolnirProtectedRoomsEvent,
-} from "matrix-protection-suite";
+} from "@the-draupnir-project/matrix-protection-suite";
 import { Draupnir } from "../../../src/Draupnir";
 import {
   MatrixRoomReference,
@@ -17,7 +17,7 @@ import {
 import { isOk } from "@gnuxie/typescript-result";
 import { SafeModeDraupnir } from "../../../src/safemode/DraupnirSafeMode";
 import { DraupnirRestartError } from "../../../src/safemode/SafeModeToggle";
-import { MatrixSendClient } from "matrix-protection-suite-for-matrix-bot-sdk";
+import { MatrixSendClient } from "@the-draupnir-project/matrix-protection-suite-for-matrix-bot-sdk";
 import { MjolnirPolicyRoomsEncodedShape } from "matrix-protection-suite/dist/Protection/PolicyListConfig/MjolnirPolicyRoomsDescription";
 import { MjolnirProtectedRoomsEncodedShape } from "matrix-protection-suite/dist/Protection/ProtectedRoomsConfig/MjolnirProtectedRoomsDescription";
 

--- a/apps/draupnir/test/integration/commands/redactCommandTest.ts
+++ b/apps/draupnir/test/integration/commands/redactCommandTest.ts
@@ -19,8 +19,8 @@ import {
   DraupnirTestContext,
 } from "../mjolnirSetupUtils";
 import { MatrixClient } from "@vector-im/matrix-bot-sdk";
-import { RoomEvent } from "matrix-protection-suite";
-import { extractRawRoomEvent } from "matrix-protection-suite-for-matrix-bot-sdk";
+import { RoomEvent } from "@the-draupnir-project/matrix-protection-suite";
+import { extractRawRoomEvent } from "@the-draupnir-project/matrix-protection-suite-for-matrix-bot-sdk";
 
 interface RedactionTestContext extends DraupnirTestContext {
   moderator?: MatrixClient;

--- a/apps/draupnir/test/integration/commands/unbanTest.ts
+++ b/apps/draupnir/test/integration/commands/unbanTest.ts
@@ -18,7 +18,7 @@ import {
   PolicyRoomEditor,
   PolicyRuleType,
   Recommendation,
-} from "matrix-protection-suite";
+} from "@the-draupnir-project/matrix-protection-suite";
 import { Draupnir } from "../../../src/Draupnir";
 import {
   MatrixRoomReference,

--- a/apps/draupnir/test/integration/fixtures.ts
+++ b/apps/draupnir/test/integration/fixtures.ts
@@ -13,7 +13,7 @@ import {
   MJOLNIR_PROTECTED_ROOMS_EVENT_TYPE,
   MJOLNIR_WATCHED_POLICY_ROOMS_EVENT_TYPE,
   StandardLifetime,
-} from "matrix-protection-suite";
+} from "@the-draupnir-project/matrix-protection-suite";
 import { configRead, getStoragePath } from "../../src/config";
 import { patchMatrixClient } from "../../src/utils";
 import {

--- a/apps/draupnir/test/integration/helloTest.ts
+++ b/apps/draupnir/test/integration/helloTest.ts
@@ -11,8 +11,8 @@
 import { MatrixClient } from "@vector-im/matrix-bot-sdk";
 import { newTestUser, noticeListener } from "./clientHelper";
 import { DraupnirTestContext } from "./mjolnirSetupUtils";
-import { SafeMatrixEmitterWrapper } from "matrix-protection-suite-for-matrix-bot-sdk";
-import { DefaultEventDecoder } from "matrix-protection-suite";
+import { SafeMatrixEmitterWrapper } from "@the-draupnir-project/matrix-protection-suite-for-matrix-bot-sdk";
+import { DefaultEventDecoder } from "@the-draupnir-project/matrix-protection-suite";
 
 describe("Test: !help command", function (this: Mocha.Suite) {
   let client: MatrixClient;

--- a/apps/draupnir/test/integration/httpAntispamTest.ts
+++ b/apps/draupnir/test/integration/httpAntispamTest.ts
@@ -8,7 +8,7 @@ import {
   ActionException,
   isOk,
   MatrixException,
-} from "matrix-protection-suite";
+} from "@the-draupnir-project/matrix-protection-suite";
 import { MatrixError } from "@vector-im/matrix-bot-sdk";
 
 describe("Test for http antispam callbacks", function () {

--- a/apps/draupnir/test/integration/manualLaunchScript.ts
+++ b/apps/draupnir/test/integration/manualLaunchScript.ts
@@ -14,7 +14,7 @@
 
 import { draupnirClient, makeBotModeToggle } from "./mjolnirSetupUtils";
 import { configRead, getStoragePath } from "../../src/config";
-import { DefaultEventDecoder } from "matrix-protection-suite";
+import { DefaultEventDecoder } from "@the-draupnir-project/matrix-protection-suite";
 import { makeTopLevelStores } from "../../src/backingstore/DraupnirStores";
 
 void (async () => {

--- a/apps/draupnir/test/integration/mjolnirSetupUtils.ts
+++ b/apps/draupnir/test/integration/mjolnirSetupUtils.ts
@@ -25,13 +25,13 @@ import {
   MatrixSendClient,
   SafeMatrixEmitter,
   SafeMatrixEmitterWrapper,
-} from "matrix-protection-suite-for-matrix-bot-sdk";
+} from "@the-draupnir-project/matrix-protection-suite-for-matrix-bot-sdk";
 import {
   DefaultEventDecoder,
   MJOLNIR_PROTECTED_ROOMS_EVENT_TYPE,
   MJOLNIR_WATCHED_POLICY_ROOMS_EVENT_TYPE,
   OwnLifetime,
-} from "matrix-protection-suite";
+} from "@the-draupnir-project/matrix-protection-suite";
 import { SafeModeDraupnir } from "../../src/safemode/DraupnirSafeMode";
 import { TopLevelStores } from "../../src/backingstore/DraupnirStores";
 import {

--- a/apps/draupnir/test/integration/protections/BlockInvitationsOnServerTest.ts
+++ b/apps/draupnir/test/integration/protections/BlockInvitationsOnServerTest.ts
@@ -12,8 +12,12 @@ import { DraupnirTestContext } from "../mjolnirSetupUtils";
 import { newTestUser } from "../clientHelper";
 import { BlockInvitationsOnServerProtection } from "../../../src/protections/BlockInvitationsOnServerProtection";
 import expect from "expect";
-import { resultifyBotSDKRequestError } from "matrix-protection-suite-for-matrix-bot-sdk";
-import { isOk, MatrixException, Ok } from "matrix-protection-suite";
+import { resultifyBotSDKRequestError } from "@the-draupnir-project/matrix-protection-suite-for-matrix-bot-sdk";
+import {
+  isOk,
+  MatrixException,
+  Ok,
+} from "@the-draupnir-project/matrix-protection-suite";
 import { MatrixError } from "@vector-im/matrix-bot-sdk";
 
 async function createWatchedPolicyRoom(

--- a/apps/draupnir/test/integration/protections/JoinRoomsOnInviteTest.ts
+++ b/apps/draupnir/test/integration/protections/JoinRoomsOnInviteTest.ts
@@ -9,7 +9,7 @@ import {
 import { newTestUser } from "../clientHelper";
 import { DraupnirTestContext } from "../mjolnirSetupUtils";
 import expect from "expect";
-import { MatrixSendClient } from "matrix-protection-suite-for-matrix-bot-sdk";
+import { MatrixSendClient } from "@the-draupnir-project/matrix-protection-suite-for-matrix-bot-sdk";
 import { Draupnir } from "../../../src/Draupnir";
 
 async function setupProtectedRooms(

--- a/apps/draupnir/test/integration/protections/RoomTakedownProtectionTest.ts
+++ b/apps/draupnir/test/integration/protections/RoomTakedownProtectionTest.ts
@@ -21,7 +21,7 @@ import {
   parsePolicyRule,
   PolicyRuleChangeType,
   PolicyRuleType,
-} from "matrix-protection-suite";
+} from "@the-draupnir-project/matrix-protection-suite";
 import { SynapseAdminRoomTakedownCapability } from "../../../src/capabilities/SynapseAdminRoomTakedown/SynapseAdminRoomTakedown";
 import { StandardDiscoveredRoomStore } from "../../../src/protections/RoomTakedown/DiscoveredRoomStore";
 import {

--- a/apps/draupnir/test/integration/throttleQueueTest.ts
+++ b/apps/draupnir/test/integration/throttleQueueTest.ts
@@ -8,7 +8,7 @@
 // https://github.com/matrix-org/mjolnir
 // </text>
 
-import { Ok } from "matrix-protection-suite";
+import { Ok } from "@the-draupnir-project/matrix-protection-suite";
 import { ThrottlingQueue } from "../../src/queues/ThrottlingQueue";
 import { DraupnirTestContext } from "./mjolnirSetupUtils";
 

--- a/apps/draupnir/test/integration/timelinePaginationTest.ts
+++ b/apps/draupnir/test/integration/timelinePaginationTest.ts
@@ -13,7 +13,7 @@ import { strict as assert } from "assert";
 import { newTestUser } from "./clientHelper";
 import { DraupnirTestContext } from "./mjolnirSetupUtils";
 import { getMessagesByUserIn } from "../../src/utils";
-import { TextMessageContent } from "matrix-protection-suite";
+import { TextMessageContent } from "@the-draupnir-project/matrix-protection-suite";
 
 /**
  * Ensure that Draupnir paginates only the necessary segment of the room timeline when backfilling.

--- a/apps/draupnir/test/integration/utilsTest.ts
+++ b/apps/draupnir/test/integration/utilsTest.ts
@@ -15,7 +15,7 @@ import {
   NoticeMessageContent,
   RoomEvent,
   Value,
-} from "matrix-protection-suite";
+} from "@the-draupnir-project/matrix-protection-suite";
 
 describe("Test: utils", function () {
   it(

--- a/apps/draupnir/test/unit/commands/BanCommandTest.ts
+++ b/apps/draupnir/test/unit/commands/BanCommandTest.ts
@@ -25,7 +25,7 @@ import {
   describeProtectedRoomsSet,
   isOk,
   randomEventID,
-} from "matrix-protection-suite";
+} from "@the-draupnir-project/matrix-protection-suite";
 import { createMock } from "ts-auto-mock";
 import expect from "expect";
 import { DraupnirBanCommand } from "../../../src/commands/Ban";

--- a/apps/draupnir/test/unit/commands/KickCommandTest.ts
+++ b/apps/draupnir/test/unit/commands/KickCommandTest.ts
@@ -17,7 +17,7 @@ import {
   RoomResolver,
   describeProtectedRoomsSet,
   isError,
-} from "matrix-protection-suite";
+} from "@the-draupnir-project/matrix-protection-suite";
 import { DraupnirKickCommand } from "../../../src/commands/KickCommand";
 import { ThrottlingQueue } from "../../../src/queues/ThrottlingQueue";
 import ManagementRoomOutput from "../../../src/managementroom/ManagementRoomOutput";

--- a/apps/draupnir/test/unit/commands/UnbanCommandTest.ts
+++ b/apps/draupnir/test/unit/commands/UnbanCommandTest.ts
@@ -22,7 +22,7 @@ import {
   RoomUnbanner,
   describeProtectedRoomsSet,
   isError,
-} from "matrix-protection-suite";
+} from "@the-draupnir-project/matrix-protection-suite";
 import { createMock } from "ts-auto-mock";
 import expect from "expect";
 import { DraupnirUnbanCommand } from "../../../src/commands/unban/Unban";

--- a/apps/draupnir/test/unit/commands/WatchUnwatchCommandTest.ts
+++ b/apps/draupnir/test/unit/commands/WatchUnwatchCommandTest.ts
@@ -15,7 +15,7 @@ import {
   WatchedPolicyRooms,
   isError,
   isOk,
-} from "matrix-protection-suite";
+} from "@the-draupnir-project/matrix-protection-suite";
 import { createMock } from "ts-auto-mock";
 import {
   DraupnirUnwatchPolicyRoomCommand,

--- a/apps/draupnir/test/unit/protections/MentionLimitProtectionTest.ts
+++ b/apps/draupnir/test/unit/protections/MentionLimitProtectionTest.ts
@@ -9,7 +9,7 @@ import {
   randomRoomID,
   randomUserID,
   RoomEvent,
-} from "matrix-protection-suite";
+} from "@the-draupnir-project/matrix-protection-suite";
 import { isContainingMentionsOverLimit } from "../../../src/protections/MentionLimitProtection";
 import expect from "expect";
 

--- a/apps/draupnir/test/unit/protections/RedactionSynchronisationTest.ts
+++ b/apps/draupnir/test/unit/protections/RedactionSynchronisationTest.ts
@@ -10,7 +10,7 @@ import {
   randomRoomID,
   randomUserID,
   Recommendation,
-} from "matrix-protection-suite";
+} from "@the-draupnir-project/matrix-protection-suite";
 import {
   RedactionSynchronisationConsequences,
   StandardRedactionSynchronisation,

--- a/apps/draupnir/test/unit/protections/RoomTakedownServiceTest.ts
+++ b/apps/draupnir/test/unit/protections/RoomTakedownServiceTest.ts
@@ -14,7 +14,7 @@ import {
   randomRoomID,
   Recommendation,
   StandardPolicyListRevision,
-} from "matrix-protection-suite";
+} from "@the-draupnir-project/matrix-protection-suite";
 import { RoomAuditLog } from "../../../src/protections/RoomTakedown/RoomAuditLog";
 import { RoomTakedownCapability } from "../../../src/capabilities/RoomTakedownCapability";
 import { StringRoomID } from "@the-draupnir-project/matrix-basic-types";

--- a/apps/draupnir/test/unit/protections/serverBanSynchronisationCapabilityRenameTest.ts
+++ b/apps/draupnir/test/unit/protections/serverBanSynchronisationCapabilityRenameTest.ts
@@ -11,7 +11,7 @@ import {
   SemanticType,
   ServerACLSynchronisationCapability,
   SimulatedServerBanSynchronisationCapability,
-} from "matrix-protection-suite";
+} from "@the-draupnir-project/matrix-protection-suite";
 
 const serverBanCapabilityName = "serverConsequences";
 

--- a/apps/draupnir/test/unit/stores/hashStoreTest.ts
+++ b/apps/draupnir/test/unit/stores/hashStoreTest.ts
@@ -14,7 +14,7 @@ import {
   randomRoomID,
   randomUserID,
   Recommendation,
-} from "matrix-protection-suite";
+} from "@the-draupnir-project/matrix-protection-suite";
 import { SHA256, enc } from "crypto-js";
 import expect from "expect";
 import {

--- a/apps/draupnir/test/unit/stores/roomAuditLogTest.ts
+++ b/apps/draupnir/test/unit/stores/roomAuditLogTest.ts
@@ -12,7 +12,7 @@ import {
   PolicyRuleType,
   randomRoomID,
   Recommendation,
-} from "matrix-protection-suite";
+} from "@the-draupnir-project/matrix-protection-suite";
 import expect from "expect";
 import { StringUserID } from "@the-draupnir-project/matrix-basic-types";
 

--- a/apps/draupnir/test/unit/stores/roomStateBackingStoreTest.ts
+++ b/apps/draupnir/test/unit/stores/roomStateBackingStoreTest.ts
@@ -9,6 +9,7 @@ import {
   DefaultEventDecoder,
   describeProtectedRoomsSet,
   describeRoomMember,
+  FakeRoomStateRevisionIssuer,
   Membership,
   PolicyRuleType,
   PowerLevelsEventContent,
@@ -16,7 +17,6 @@ import {
   Recommendation,
 } from "@the-draupnir-project/matrix-protection-suite";
 import { StringUserID } from "@the-draupnir-project/matrix-basic-types";
-import { FakeRoomStateRevisionIssuer } from "matrix-protection-suite/dist/StateTracking/FakeRoomStateRevisionIssuer";
 import expect from "expect";
 
 function makeStore(): SqliteRoomStateBackingStore {

--- a/apps/draupnir/test/unit/stores/roomStateBackingStoreTest.ts
+++ b/apps/draupnir/test/unit/stores/roomStateBackingStoreTest.ts
@@ -14,7 +14,7 @@ import {
   PowerLevelsEventContent,
   randomRoomID,
   Recommendation,
-} from "matrix-protection-suite";
+} from "@the-draupnir-project/matrix-protection-suite";
 import { StringUserID } from "@the-draupnir-project/matrix-basic-types";
 import { FakeRoomStateRevisionIssuer } from "matrix-protection-suite/dist/StateTracking/FakeRoomStateRevisionIssuer";
 import expect from "expect";

--- a/apps/draupnir/test/unit/stores/userRestrictionAuditLogTest.ts
+++ b/apps/draupnir/test/unit/stores/userRestrictionAuditLogTest.ts
@@ -12,9 +12,9 @@ import {
   randomRoomID,
   randomUserID,
   Recommendation,
-} from "matrix-protection-suite";
+} from "@the-draupnir-project/matrix-protection-suite";
 import expect from "expect";
-import { AccountRestriction } from "matrix-protection-suite-for-matrix-bot-sdk";
+import { AccountRestriction } from "@the-draupnir-project/matrix-protection-suite-for-matrix-bot-sdk";
 import { SqliteUserRestrictionAuditLog } from "../../../src/protections/HomeserverUserPolicyApplication/SqliteUserRestrictionAuditLog";
 
 describe("UserAuditLog test", function () {

--- a/package-lock.json
+++ b/package-lock.json
@@ -36,6 +36,8 @@
         "@sinclair/typebox": "0.34.49",
         "@the-draupnir-project/interface-manager": "4.2.6",
         "@the-draupnir-project/matrix-basic-types": "1.5.1",
+        "@the-draupnir-project/matrix-protection-suite": "7.1.0",
+        "@the-draupnir-project/matrix-protection-suite-for-matrix-bot-sdk": "5.0.1",
         "@the-draupnir-project/mps-interface-adaptor": "0.6.0",
         "@vector-im/matrix-bot-sdk": "^0.8.0-element.3",
         "better-sqlite3": "^12.8.0",
@@ -46,8 +48,6 @@
         "js-yaml": "^4.1.0",
         "jsdom": "^24.0.0",
         "matrix-appservice-bridge": "^11.2.0",
-        "matrix-protection-suite": "npm:@the-draupnir-project/matrix-protection-suite@7.1.0",
-        "matrix-protection-suite-for-matrix-bot-sdk": "npm:@the-draupnir-project/matrix-protection-suite@5.0.1",
         "pg": "^8.8.0",
         "yaml": "^2.3.2"
       },
@@ -10608,14 +10608,6 @@
         "nedb": "^1.8.0"
       }
     },
-    "node_modules/matrix-protection-suite": {
-      "resolved": "packages/matrix-protection-suite",
-      "link": true
-    },
-    "node_modules/matrix-protection-suite-for-matrix-bot-sdk": {
-      "resolved": "packages/matrix-protection-suite-for-matrix-bot-sdk",
-      "link": true
-    },
     "node_modules/mdast-util-to-hast": {
       "version": "13.2.1",
       "resolved": "https://registry.npmjs.org/mdast-util-to-hast/-/mdast-util-to-hast-13.2.1.tgz",
@@ -14659,18 +14651,18 @@
         "await-lock": "^2.2.2"
       },
       "devDependencies": {
+        "@the-draupnir-project/matrix-protection-suite": "7.1.0",
         "@types/crypto-js": "^4.1.2",
         "@types/glob-to-regexp": "^0.4.1",
         "@types/node": "^24.12.4",
         "@vector-im/matrix-bot-sdk": "0.8.0-element.3",
-        "matrix-protection-suite": "npm:@the-draupnir-project/matrix-protection-suite@7.1.0",
         "typedoc": "^0.26.3"
       },
       "peerDependencies": {
         "@sinclair/typebox": "0.34.49",
         "@the-draupnir-project/matrix-basic-types": "1.5.1",
-        "@vector-im/matrix-bot-sdk": "^0.8.0-element.3",
-        "matrix-protection-suite": "npm:@the-draupnir-project/matrix-protection-suite@7.1.0"
+        "@the-draupnir-project/matrix-protection-suite": "7.1.0",
+        "@vector-im/matrix-bot-sdk": "^0.8.0-element.3"
       }
     },
     "packages/matrix-protection-suite-for-matrix-bot-sdk/node_modules/@types/node": {
@@ -14789,14 +14781,14 @@
       "version": "0.6.0",
       "license": "Apache-2.0",
       "devDependencies": {
-        "@types/node": "^24.12.4",
-        "matrix-protection-suite": "npm:@the-draupnir-project/matrix-protection-suite@7.1.0"
+        "@the-draupnir-project/matrix-protection-suite": "7.1.0",
+        "@types/node": "^24.12.4"
       },
       "peerDependencies": {
         "@gnuxie/typescript-result": "^1.0.0",
         "@sinclair/typebox": "^0.34.49",
         "@the-draupnir-project/interface-manager": "^4.2.3",
-        "matrix-protection-suite": "npm:@the-draupnir-project/matrix-protection-suite@7.1.0"
+        "@the-draupnir-project/matrix-protection-suite": "7.1.0"
       }
     },
     "packages/mps-interface-adaptor/node_modules/@types/node": {

--- a/package.json
+++ b/package.json
@@ -17,10 +17,10 @@
   },
   "homepage": "https://github.com/the-draupnir-project/Draupnir#readme",
   "scripts": {
-    "build": "tsc -b && npm run -ws build:assets --if-present",
-    "build:all": "tsc -b tsconfig.all.json && npm run -ws build:assets --if-present",
+    "build": "tsc -b && npm run --workspaces build:assets --if-present",
+    "build:all": "tsc -b tsconfig.all.json && npm run --workspaces build:assets --if-present",
     "build:clean": "tsc -b --clean",
-    "test": "npm run -ws test --if-present && npm run -w apps/draupnir test:unit",
+    "test": "npm run --workspaces test --if-present && npm run -w apps/draupnir test:unit",
     "lint": "eslint --cache 'packages/**/*.{ts,tsx}' 'apps/**/*.{ts,tsx}' && prettier --cache --ignore-unknown --check ."
   },
   "devDependencies": {

--- a/packages/matrix-protection-suite-for-matrix-bot-sdk/package.json
+++ b/packages/matrix-protection-suite-for-matrix-bot-sdk/package.json
@@ -22,11 +22,11 @@
     "make:docs": "typedoc"
   },
   "devDependencies": {
+    "@the-draupnir-project/matrix-protection-suite": "7.1.0",
     "@types/crypto-js": "^4.1.2",
     "@types/glob-to-regexp": "^0.4.1",
     "@types/node": "^24.12.4",
     "@vector-im/matrix-bot-sdk": "0.8.0-element.3",
-    "matrix-protection-suite": "npm:@the-draupnir-project/matrix-protection-suite@7.1.0",
     "typedoc": "^0.26.3"
   },
   "dependencies": {
@@ -36,8 +36,8 @@
   "peerDependencies": {
     "@sinclair/typebox": "0.34.49",
     "@the-draupnir-project/matrix-basic-types": "1.5.1",
-    "@vector-im/matrix-bot-sdk": "^0.8.0-element.3",
-    "matrix-protection-suite": "npm:@the-draupnir-project/matrix-protection-suite@7.1.0"
+    "@the-draupnir-project/matrix-protection-suite": "7.1.0",
+    "@vector-im/matrix-bot-sdk": "^0.8.0-element.3"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/matrix-protection-suite-for-matrix-bot-sdk/src/Client/BotSDKAllClient.ts
+++ b/packages/matrix-protection-suite-for-matrix-bot-sdk/src/Client/BotSDKAllClient.ts
@@ -8,7 +8,7 @@ import {
   RoomCreator,
   RoomJoiner,
   RoomStateEventSender,
-} from "matrix-protection-suite";
+} from "@the-draupnir-project/matrix-protection-suite";
 import { MatrixSendClient } from "../MatrixEmitter";
 import { BotSDKBaseClient } from "./BotSDKBaseClient";
 import { StringRoomID } from "@the-draupnir-project/matrix-basic-types";

--- a/packages/matrix-protection-suite-for-matrix-bot-sdk/src/Client/BotSDKBaseClient.ts
+++ b/packages/matrix-protection-suite-for-matrix-bot-sdk/src/Client/BotSDKBaseClient.ts
@@ -40,7 +40,7 @@ import {
   RoomEventRelationsPaginator,
   RoomEventRelationsOptions,
   RoomEventRelationsResponse,
-} from "matrix-protection-suite";
+} from "@the-draupnir-project/matrix-protection-suite";
 import { MatrixSendClient } from "../MatrixEmitter";
 import {
   MatrixRoomID,

--- a/packages/matrix-protection-suite-for-matrix-bot-sdk/src/Client/BotSDKBaseClient.ts
+++ b/packages/matrix-protection-suite-for-matrix-bot-sdk/src/Client/BotSDKBaseClient.ts
@@ -40,6 +40,8 @@ import {
   RoomEventRelationsPaginator,
   RoomEventRelationsOptions,
   RoomEventRelationsResponse,
+  RoomEventGetter,
+  RoomReactionSender,
 } from "@the-draupnir-project/matrix-protection-suite";
 import { MatrixSendClient } from "../MatrixEmitter";
 import {
@@ -53,8 +55,6 @@ import {
 } from "@the-draupnir-project/matrix-basic-types";
 import { resolveRoomReferenceSafe } from "../SafeMatrixClient";
 import { ResultError } from "@gnuxie/typescript-result";
-import { RoomReactionSender } from "matrix-protection-suite/dist/Client/RoomReactionSender";
-import { RoomEventGetter } from "matrix-protection-suite/dist/Client/RoomEventGetter";
 import { BotSDKJunkError, toMatrixJunkError } from "./BotSDKJunkErrors";
 
 const log = new Logger("BotSDKBaseClient");

--- a/packages/matrix-protection-suite-for-matrix-bot-sdk/src/Client/BotSDKClientPlatform.ts
+++ b/packages/matrix-protection-suite-for-matrix-bot-sdk/src/Client/BotSDKClientPlatform.ts
@@ -18,7 +18,7 @@ import {
   RoomStateEventSender,
   RoomStateGetter,
   RoomUnbanner,
-} from "matrix-protection-suite";
+} from "@the-draupnir-project/matrix-protection-suite";
 import { BotSDKBaseClient } from "./BotSDKBaseClient";
 import { RoomReactionSender } from "matrix-protection-suite/dist/Client/RoomReactionSender";
 import { RoomEventGetter } from "matrix-protection-suite/dist/Client/RoomEventGetter";

--- a/packages/matrix-protection-suite-for-matrix-bot-sdk/src/Client/BotSDKClientPlatform.ts
+++ b/packages/matrix-protection-suite-for-matrix-bot-sdk/src/Client/BotSDKClientPlatform.ts
@@ -8,20 +8,20 @@ import {
   RoomBanner,
   RoomCreator,
   RoomEventRedacter,
+  RoomEventGetter,
   RoomEventRelations,
   RoomInviter,
   RoomJoiner,
   RoomKicker,
   RoomMessages,
   RoomMessageSender,
+  RoomReactionSender,
   RoomResolver,
   RoomStateEventSender,
   RoomStateGetter,
   RoomUnbanner,
 } from "@the-draupnir-project/matrix-protection-suite";
 import { BotSDKBaseClient } from "./BotSDKBaseClient";
-import { RoomReactionSender } from "matrix-protection-suite/dist/Client/RoomReactionSender";
-import { RoomEventGetter } from "matrix-protection-suite/dist/Client/RoomEventGetter";
 
 export class BotSDKClientPlatform implements ClientPlatform {
   constructor(private readonly allClient: BotSDKBaseClient) {

--- a/packages/matrix-protection-suite-for-matrix-bot-sdk/src/Client/BotSDKJunkErrors.ts
+++ b/packages/matrix-protection-suite-for-matrix-bot-sdk/src/Client/BotSDKJunkErrors.ts
@@ -4,7 +4,10 @@
 
 import { Type } from "@sinclair/typebox";
 import { MatrixError } from "@vector-im/matrix-bot-sdk";
-import { Value, assertThrowableIsError } from "matrix-protection-suite";
+import {
+  Value,
+  assertThrowableIsError,
+} from "@the-draupnir-project/matrix-protection-suite";
 
 const MatrixErrorBody = Type.Object({
   errcode: Type.String(),

--- a/packages/matrix-protection-suite-for-matrix-bot-sdk/src/ClientManagement/ClientCapabilityFactory.ts
+++ b/packages/matrix-protection-suite-for-matrix-bot-sdk/src/ClientManagement/ClientCapabilityFactory.ts
@@ -6,7 +6,7 @@ import {
   ClientPlatform,
   ClientsInRoomMap,
   EventDecoder,
-} from "matrix-protection-suite";
+} from "@the-draupnir-project/matrix-protection-suite";
 import { MatrixSendClient } from "../MatrixEmitter";
 import { BotSDKClientPlatform } from "../Client/BotSDKClientPlatform";
 import { BotSDKAllClient } from "../Client/BotSDKAllClient";

--- a/packages/matrix-protection-suite-for-matrix-bot-sdk/src/ClientManagement/ClientManagement.ts
+++ b/packages/matrix-protection-suite-for-matrix-bot-sdk/src/ClientManagement/ClientManagement.ts
@@ -10,7 +10,7 @@ import {
   ClientsInRoomMap,
   Ok,
   assertThrowableIsError,
-} from "matrix-protection-suite";
+} from "@the-draupnir-project/matrix-protection-suite";
 import { MatrixSendClient } from "../MatrixEmitter";
 import {
   StringRoomID,

--- a/packages/matrix-protection-suite-for-matrix-bot-sdk/src/ClientManagement/JoinedRoomsSafe.ts
+++ b/packages/matrix-protection-suite-for-matrix-bot-sdk/src/ClientManagement/JoinedRoomsSafe.ts
@@ -8,7 +8,7 @@ import {
   JoinedRoomsSafe,
   Ok,
   assertThrowableIsError,
-} from "matrix-protection-suite";
+} from "@the-draupnir-project/matrix-protection-suite";
 import { MatrixSendClient } from "../MatrixEmitter";
 import { StringRoomID } from "@the-draupnir-project/matrix-basic-types";
 

--- a/packages/matrix-protection-suite-for-matrix-bot-sdk/src/ClientManagement/RoomStateManagerFactory.ts
+++ b/packages/matrix-protection-suite-for-matrix-bot-sdk/src/ClientManagement/RoomStateManagerFactory.ts
@@ -16,6 +16,7 @@ import {
   PolicyRoomRevisionIssuer,
   PolicyRuleType,
   ResultError,
+  Redaction,
   RoomCreateEvent,
   RoomEvent,
   RoomMembershipManager,
@@ -39,7 +40,6 @@ import {
 import { ClientForUserID } from "./ClientManagement";
 import { BotSDKRoomMembershipManager } from "../StateTracking/RoomMembershipManager";
 import { BotSDKPolicyRoomManager } from "../PolicyList/PolicyListManager";
-import { Redaction } from "matrix-protection-suite/dist/MatrixTypes/Redaction";
 import { BotSDKClientPlatform } from "../Client/BotSDKClientPlatform";
 import { BotSDKBaseClient } from "../Client/BotSDKBaseClient";
 import {

--- a/packages/matrix-protection-suite-for-matrix-bot-sdk/src/ClientManagement/RoomStateManagerFactory.ts
+++ b/packages/matrix-protection-suite-for-matrix-bot-sdk/src/ClientManagement/RoomStateManagerFactory.ts
@@ -35,7 +35,7 @@ import {
   StateEvent,
   isError,
   isOk,
-} from "matrix-protection-suite";
+} from "@the-draupnir-project/matrix-protection-suite";
 import { ClientForUserID } from "./ClientManagement";
 import { BotSDKRoomMembershipManager } from "../StateTracking/RoomMembershipManager";
 import { BotSDKPolicyRoomManager } from "../PolicyList/PolicyListManager";

--- a/packages/matrix-protection-suite-for-matrix-bot-sdk/src/ClientManagement/RoomStateRefresh.ts
+++ b/packages/matrix-protection-suite-for-matrix-bot-sdk/src/ClientManagement/RoomStateRefresh.ts
@@ -6,7 +6,7 @@ import AwaitLock from "await-lock";
 import {
   Logger,
   StandardRoomStateRevisionIssuer,
-} from "matrix-protection-suite";
+} from "@the-draupnir-project/matrix-protection-suite";
 
 const log = new Logger("RoomStateRefresh");
 

--- a/packages/matrix-protection-suite-for-matrix-bot-sdk/src/Interface/MatrixData.ts
+++ b/packages/matrix-protection-suite-for-matrix-bot-sdk/src/Interface/MatrixData.ts
@@ -14,7 +14,7 @@ import {
   Value,
   assertThrowableIsError,
   isError,
-} from "matrix-protection-suite";
+} from "@the-draupnir-project/matrix-protection-suite";
 import { MatrixSendClient } from "../MatrixEmitter";
 import {
   is404,

--- a/packages/matrix-protection-suite-for-matrix-bot-sdk/src/Logging/BotSDKLogging.ts
+++ b/packages/matrix-protection-suite-for-matrix-bot-sdk/src/Logging/BotSDKLogging.ts
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { LogService } from "@vector-im/matrix-bot-sdk";
-import { ILoggerProvider } from "matrix-protection-suite";
+import { ILoggerProvider } from "@the-draupnir-project/matrix-protection-suite";
 
 /**
  * A logger provider that uses the `LogService` from the bot-sdk to provide logging capability.

--- a/packages/matrix-protection-suite-for-matrix-bot-sdk/src/MatrixEmitter.ts
+++ b/packages/matrix-protection-suite-for-matrix-bot-sdk/src/MatrixEmitter.ts
@@ -21,7 +21,7 @@ import {
   Logger,
   RoomEvent,
   RoomMessage,
-} from "matrix-protection-suite";
+} from "@the-draupnir-project/matrix-protection-suite";
 
 const log = new Logger("MatrixEmitter");
 

--- a/packages/matrix-protection-suite-for-matrix-bot-sdk/src/PolicyList/PolicyListManager.ts
+++ b/packages/matrix-protection-suite-for-matrix-bot-sdk/src/PolicyList/PolicyListManager.ts
@@ -32,7 +32,7 @@ import {
   ClientPlatform,
   RoomVersionMirror,
   RoomEvent,
-} from "matrix-protection-suite";
+} from "@the-draupnir-project/matrix-protection-suite";
 import { MatrixSendClient } from "../MatrixEmitter";
 import { RoomStateManagerFactory } from "../ClientManagement/RoomStateManagerFactory";
 import {

--- a/packages/matrix-protection-suite-for-matrix-bot-sdk/src/Protection/MjolnirProtectedRoomsStore.ts
+++ b/packages/matrix-protection-suite-for-matrix-bot-sdk/src/Protection/MjolnirProtectedRoomsStore.ts
@@ -13,7 +13,7 @@ import {
   isError,
   Ok,
   assertThrowableIsError,
-} from "matrix-protection-suite";
+} from "@the-draupnir-project/matrix-protection-suite";
 import { MatrixSendClient } from "../MatrixEmitter";
 
 export class BotSDKMjolnirProtectedRoomsStore implements PersistentMatrixData<

--- a/packages/matrix-protection-suite-for-matrix-bot-sdk/src/Protection/MjolnirWatchedPolicyRoomsStore.ts
+++ b/packages/matrix-protection-suite-for-matrix-bot-sdk/src/Protection/MjolnirWatchedPolicyRoomsStore.ts
@@ -13,7 +13,7 @@ import {
   MjolnirWatchedPolicyRoomsEvent,
   MJOLNIR_WATCHED_POLICY_ROOMS_EVENT_TYPE,
   assertThrowableIsError,
-} from "matrix-protection-suite";
+} from "@the-draupnir-project/matrix-protection-suite";
 import { MatrixSendClient } from "../MatrixEmitter";
 
 export class BotSDKMjolnirWatchedPolicyRoomsStore implements PersistentMatrixData<

--- a/packages/matrix-protection-suite-for-matrix-bot-sdk/src/SafeMatrixClient.ts
+++ b/packages/matrix-protection-suite-for-matrix-bot-sdk/src/SafeMatrixClient.ts
@@ -7,7 +7,7 @@ import {
   Ok,
   StringRoomIDSchema,
   Value,
-} from "matrix-protection-suite";
+} from "@the-draupnir-project/matrix-protection-suite";
 import { MatrixSendClient } from "./MatrixEmitter";
 import {
   MatrixRoomReference,

--- a/packages/matrix-protection-suite-for-matrix-bot-sdk/src/StateTracking/RoomMembershipManager.ts
+++ b/packages/matrix-protection-suite-for-matrix-bot-sdk/src/StateTracking/RoomMembershipManager.ts
@@ -14,8 +14,8 @@ import {
   Value,
   assertThrowableIsError,
   isError,
-} from "matrix-protection-suite";
-import { MembershipEvent } from "matrix-protection-suite";
+} from "@the-draupnir-project/matrix-protection-suite";
+import { MembershipEvent } from "@the-draupnir-project/matrix-protection-suite";
 import { MatrixSendClient } from "../MatrixEmitter";
 import { RoomStateManagerFactory } from "../ClientManagement/RoomStateManagerFactory";
 import {

--- a/packages/matrix-protection-suite-for-matrix-bot-sdk/src/SynapseAdmin/BlockStatusEndpoint.ts
+++ b/packages/matrix-protection-suite-for-matrix-bot-sdk/src/SynapseAdmin/BlockStatusEndpoint.ts
@@ -3,7 +3,10 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { Type } from "@sinclair/typebox";
-import { EDStatic, StringUserIDSchema } from "matrix-protection-suite";
+import {
+  EDStatic,
+  StringUserIDSchema,
+} from "@the-draupnir-project/matrix-protection-suite";
 
 export type BlockStatusResponse = EDStatic<typeof BlockStatusResponse>;
 export const BlockStatusResponse = Type.Object({

--- a/packages/matrix-protection-suite-for-matrix-bot-sdk/src/SynapseAdmin/RoomDetailsEndpoint.ts
+++ b/packages/matrix-protection-suite-for-matrix-bot-sdk/src/SynapseAdmin/RoomDetailsEndpoint.ts
@@ -11,7 +11,7 @@ import {
   EDStatic,
   StringRoomAliasSchema,
   StringRoomIDSchema,
-} from "matrix-protection-suite";
+} from "@the-draupnir-project/matrix-protection-suite";
 
 // There is a bug in Synapse at the moment where the creator can be blank.
 // https://github.com/element-hq/synapse/issues/18563

--- a/packages/matrix-protection-suite-for-matrix-bot-sdk/src/SynapseAdmin/RoomListEndpoint.ts
+++ b/packages/matrix-protection-suite-for-matrix-bot-sdk/src/SynapseAdmin/RoomListEndpoint.ts
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { Type } from "@sinclair/typebox";
-import { EDStatic } from "matrix-protection-suite";
+import { EDStatic } from "@the-draupnir-project/matrix-protection-suite";
 import { RoomDetailsResponse } from "./RoomDetailsEndpoint";
 
 export interface RoomListQueryParams {

--- a/packages/matrix-protection-suite-for-matrix-bot-sdk/src/SynapseAdmin/ShutdownV2Endpoint.ts
+++ b/packages/matrix-protection-suite-for-matrix-bot-sdk/src/SynapseAdmin/ShutdownV2Endpoint.ts
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { Type } from "@sinclair/typebox";
-import { EDStatic } from "matrix-protection-suite";
+import { EDStatic } from "@the-draupnir-project/matrix-protection-suite";
 
 export type SynapseRoomShutdownV2RequestBody = EDStatic<
   typeof SynapseRoomShutdownV2RequestBody

--- a/packages/matrix-protection-suite-for-matrix-bot-sdk/src/SynapseAdmin/SynapseAdminClient.ts
+++ b/packages/matrix-protection-suite-for-matrix-bot-sdk/src/SynapseAdmin/SynapseAdminClient.ts
@@ -21,7 +21,7 @@ import {
   Value,
   assertThrowableIsError,
   isError,
-} from "matrix-protection-suite";
+} from "@the-draupnir-project/matrix-protection-suite";
 import { MatrixSendClient } from "../MatrixEmitter";
 import {
   StringRoomID,

--- a/packages/matrix-protection-suite-for-matrix-bot-sdk/src/SynapseAdmin/UserDetailsEndpoint.ts
+++ b/packages/matrix-protection-suite-for-matrix-bot-sdk/src/SynapseAdmin/UserDetailsEndpoint.ts
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { Type } from "@sinclair/typebox";
-import { EDStatic } from "matrix-protection-suite";
+import { EDStatic } from "@the-draupnir-project/matrix-protection-suite";
 
 export type UserDetailsResponse = EDStatic<typeof UserDetailsResponse>;
 export const UserDetailsResponse = Type.Object({

--- a/packages/matrix-protection-suite-for-matrix-bot-sdk/src/SynapseAdmin/UserRedactionEndpoint.ts
+++ b/packages/matrix-protection-suite-for-matrix-bot-sdk/src/SynapseAdmin/UserRedactionEndpoint.ts
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { Type } from "@sinclair/typebox";
-import { EDStatic } from "matrix-protection-suite";
+import { EDStatic } from "@the-draupnir-project/matrix-protection-suite";
 
 export type UserRedactionResponse = EDStatic<typeof UserRedactionResponse>;
 export const UserRedactionResponse = Type.Object({

--- a/packages/matrix-protection-suite-for-matrix-bot-sdk/src/index.ts
+++ b/packages/matrix-protection-suite-for-matrix-bot-sdk/src/index.ts
@@ -26,5 +26,7 @@ export * from "./Protection/MjolnirWatchedPolicyRoomsStore";
 export * from "./StateTracking/RoomMembershipManager";
 
 export * from "./SynapseAdmin/SynapseAdminClient";
+export * from "./SynapseAdmin/RoomListEndpoint";
+export * from "./SynapseAdmin/UserDetailsEndpoint";
 
 export * from "./SafeMatrixClient";

--- a/packages/matrix-protection-suite/src/index.ts
+++ b/packages/matrix-protection-suite/src/index.ts
@@ -17,6 +17,7 @@ export * from "./Client/PowerLevelsMirror";
 export * from "./Client/RoomBanner";
 export * from "./Client/RoomCreator";
 export * from "./Client/RoomEventFilter";
+export * from "./Client/RoomEventGetter";
 export * from "./Client/RoomEventRedacter";
 export * from "./Client/RoomEventRelations";
 export * from "./Client/RoomInviter";
@@ -24,6 +25,7 @@ export * from "./Client/RoomJoiner";
 export * from "./Client/RoomKicker";
 export * from "./Client/RoomMessages";
 export * from "./Client/RoomMessageSender";
+export * from "./Client/RoomReactionSender";
 export * from "./Client/RoomResolver";
 export * from "./Client/RoomStateGetter";
 
@@ -214,6 +216,7 @@ export * from "./SafeMatrixEvents/UnsafeEvent";
 
 export * from "./StateTracking/DeclareRoomState";
 export * from "./StateTracking/EventBatch";
+export * from "./StateTracking/FakeRoomStateRevisionIssuer";
 export * from "./StateTracking/RoomStateBackingStore";
 export * from "./StateTracking/SetRoomState";
 export * from "./StateTracking/StandardRoomStateRevision";

--- a/packages/mps-interface-adaptor/package.json
+++ b/packages/mps-interface-adaptor/package.json
@@ -22,14 +22,14 @@
   },
   "private": false,
   "devDependencies": {
-    "@types/node": "^24.12.4",
-    "matrix-protection-suite": "npm:@the-draupnir-project/matrix-protection-suite@7.1.0"
+    "@the-draupnir-project/matrix-protection-suite": "7.1.0",
+    "@types/node": "^24.12.4"
   },
   "peerDependencies": {
     "@gnuxie/typescript-result": "^1.0.0",
     "@sinclair/typebox": "^0.34.49",
     "@the-draupnir-project/interface-manager": "^4.2.3",
-    "matrix-protection-suite": "npm:@the-draupnir-project/matrix-protection-suite@7.1.0"
+    "@the-draupnir-project/matrix-protection-suite": "7.1.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/mps-interface-adaptor/src/MPSInterfaceAdaptor/CommonRenderers.tsx
+++ b/packages/mps-interface-adaptor/src/MPSInterfaceAdaptor/CommonRenderers.tsx
@@ -20,7 +20,7 @@ import {
   ResultForUsersInRoom,
   RoomSetResult,
   isOk,
-} from "matrix-protection-suite";
+} from "@the-draupnir-project/matrix-protection-suite";
 import {
   StringRoomID,
   MatrixRoomReference,

--- a/packages/mps-interface-adaptor/src/MPSInterfaceAdaptor/MPSMatrixInterfaceAdaptor.ts
+++ b/packages/mps-interface-adaptor/src/MPSInterfaceAdaptor/MPSMatrixInterfaceAdaptor.ts
@@ -22,7 +22,7 @@ import {
   RoomEvent,
   RoomMessageSender,
   isError,
-} from "matrix-protection-suite";
+} from "@the-draupnir-project/matrix-protection-suite";
 import { MatrixReactionHandler } from "./MatrixReactionHandler";
 import {
   BasicInvocationInformation,

--- a/packages/mps-interface-adaptor/src/MPSInterfaceAdaptor/MatrixHelpRenderer.tsx
+++ b/packages/mps-interface-adaptor/src/MPSInterfaceAdaptor/MatrixHelpRenderer.tsx
@@ -15,6 +15,7 @@ import {
   Ok,
   RoomEvent,
   RoomMessageSender,
+  RoomReactionSender,
   Task,
   isError,
   isOk,
@@ -27,6 +28,7 @@ import {
   DeadDocumentJSX,
   DocumentNode,
   ParameterDescription,
+  printPresentationSchema,
   RestDescription,
   TextPresentationRenderer,
   CommandTable,
@@ -41,8 +43,6 @@ import {
   sendMatrixEventsFromDeadDocument,
 } from "./MPSMatrixInterfaceAdaptor";
 import { Result } from "@gnuxie/typescript-result";
-import { printPresentationSchema } from "@the-draupnir-project/interface-manager/dist/Command/PresentationSchema";
-import { RoomReactionSender } from "@the-draupnir-project/matrix-protection-suite/dist/Client/RoomReactionSender";
 import { replyNoticeText } from "./replyNotice";
 import {
   renderDetailsNotice,

--- a/packages/mps-interface-adaptor/src/MPSInterfaceAdaptor/MatrixHelpRenderer.tsx
+++ b/packages/mps-interface-adaptor/src/MPSInterfaceAdaptor/MatrixHelpRenderer.tsx
@@ -18,7 +18,7 @@ import {
   Task,
   isError,
   isOk,
-} from "matrix-protection-suite";
+} from "@the-draupnir-project/matrix-protection-suite";
 import { MatrixRoomReference } from "@the-draupnir-project/matrix-basic-types";
 import {
   ArgumentParseError,
@@ -42,7 +42,7 @@ import {
 } from "./MPSMatrixInterfaceAdaptor";
 import { Result } from "@gnuxie/typescript-result";
 import { printPresentationSchema } from "@the-draupnir-project/interface-manager/dist/Command/PresentationSchema";
-import { RoomReactionSender } from "matrix-protection-suite/dist/Client/RoomReactionSender";
+import { RoomReactionSender } from "@the-draupnir-project/matrix-protection-suite/dist/Client/RoomReactionSender";
 import { replyNoticeText } from "./replyNotice";
 import {
   renderDetailsNotice,

--- a/packages/mps-interface-adaptor/src/MPSInterfaceAdaptor/MatrixPromptForAccept.tsx
+++ b/packages/mps-interface-adaptor/src/MPSInterfaceAdaptor/MatrixPromptForAccept.tsx
@@ -7,7 +7,12 @@
 // https://github.com/the-draupnir-project/Draupnir
 // </text>
 
-import { Logger, Task, Value, isError } from "matrix-protection-suite";
+import {
+  Logger,
+  Task,
+  Value,
+  isError,
+} from "@the-draupnir-project/matrix-protection-suite";
 import {
   MatrixReactionHandler,
   ReactionListener,

--- a/packages/mps-interface-adaptor/src/MPSInterfaceAdaptor/MatrixPromptForConfirmation.tsx
+++ b/packages/mps-interface-adaptor/src/MPSInterfaceAdaptor/MatrixPromptForConfirmation.tsx
@@ -19,7 +19,12 @@ import {
   MatrixInterfaceCommandDispatcher,
   TextPresentationRenderer,
 } from "@the-draupnir-project/interface-manager";
-import { Logger, RoomEvent, Task, Value } from "matrix-protection-suite";
+import {
+  Logger,
+  RoomEvent,
+  Task,
+  Value,
+} from "@the-draupnir-project/matrix-protection-suite";
 import {
   MatrixReactionHandler,
   ReactionListener,

--- a/packages/mps-interface-adaptor/src/MPSInterfaceAdaptor/MatrixReactionHandler.ts
+++ b/packages/mps-interface-adaptor/src/MPSInterfaceAdaptor/MatrixReactionHandler.ts
@@ -18,7 +18,7 @@ import {
   Task,
   Value,
   isError,
-} from "matrix-protection-suite";
+} from "@the-draupnir-project/matrix-protection-suite";
 import {
   StringRoomID,
   StringUserID,

--- a/packages/mps-interface-adaptor/src/MPSInterfaceAdaptor/replyNotice.ts
+++ b/packages/mps-interface-adaptor/src/MPSInterfaceAdaptor/replyNotice.ts
@@ -7,7 +7,7 @@
 // https://github.com/the-draupnir-project/Draupnir
 // </text>
 
-import { RoomMessageSender } from "matrix-protection-suite";
+import { RoomMessageSender } from "@the-draupnir-project/matrix-protection-suite";
 import { Result } from "@gnuxie/typescript-result";
 import {
   StringEventID,


### PR DESCRIPTION
This should simplify release workflow in the monorepo tooling https://github.com/the-draupnir-project/Draupnir/issues/1124.
And also prevent issues like https://github.com/the-draupnir-project/Draupnir/commit/4e63164046153c656050c6d0a325c79f1492153a. 