### PR TITLE
Fix CI isues related to the node.js matrix crypto package

### DIFF
--- a/.github/workflows/mjolnir.yml
+++ b/.github/workflows/mjolnir.yml
@@ -44,7 +44,47 @@ jobs:
           node-version: "24"
           cache: "npm"
           cache-dependency-path: package-lock.json
-      - run: corepack npm install
+      - name: Install dependencies and show native postinstall output
+        run: corepack npm install --foreground-scripts
+      - name: Diagnose matrix-sdk-crypto native binding
+        run: |
+          node --version
+          corepack npm --version
+          node - <<'NODE'
+          const { existsSync } = require("node:fs");
+          const { dirname, join } = require("node:path");
+
+          const cryptoEntry = require.resolve("@matrix-org/matrix-sdk-crypto-nodejs");
+          const cryptoDirectory = dirname(cryptoEntry);
+          const nativeBinding = join(
+            cryptoDirectory,
+            "matrix-sdk-crypto.linux-x64-gnu.node"
+          );
+          let fallbackPackage;
+          try {
+            fallbackPackage = require.resolve(
+              "@matrix-org/matrix-sdk-crypto-nodejs-linux-x64-gnu"
+            );
+          } catch (error) {
+            fallbackPackage = error.code;
+          }
+
+          console.log({
+            platform: process.platform,
+            arch: process.arch,
+            glibc: process.report.getReport().header.glibcVersionRuntime,
+            cryptoEntry,
+            nativeBinding,
+            nativeBindingExists: existsSync(nativeBinding),
+            fallbackPackage,
+          });
+
+          if (!existsSync(nativeBinding) && fallbackPackage === "MODULE_NOT_FOUND") {
+            throw new Error(
+              "matrix-sdk-crypto postinstall neither downloaded its native binding nor installed its fallback package"
+            );
+          }
+          NODE
       - run: corepack npm run build:all
       - run: corepack npm run test
   integration:

--- a/apps/draupnir/package.json
+++ b/apps/draupnir/package.json
@@ -47,7 +47,7 @@
     "@the-draupnir-project/interface-manager": "4.2.6",
     "@the-draupnir-project/matrix-basic-types": "1.5.1",
     "@the-draupnir-project/mps-interface-adaptor": "0.6.0",
-    "@vector-im/matrix-bot-sdk": "^0.8.0-element.3",
+    "@vector-im/matrix-bot-sdk": "0.9.0-element.1",
     "better-sqlite3": "^12.8.0",
     "body-parser": "^1.20.2",
     "config": "^3.3.9",

--- a/apps/draupnir/package.json
+++ b/apps/draupnir/package.json
@@ -55,7 +55,7 @@
     "html-to-text": "^8.0.0",
     "js-yaml": "^4.1.0",
     "jsdom": "^24.0.0",
-    "matrix-appservice-bridge": "^11.2.0",
+    "matrix-appservice-bridge": "11.2.0",
     "matrix-protection-suite": "npm:@the-draupnir-project/matrix-protection-suite@7.1.0",
     "matrix-protection-suite-for-matrix-bot-sdk": "npm:@the-draupnir-project/matrix-protection-suite@5.0.1",
     "pg": "^8.8.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -37,7 +37,7 @@
         "@the-draupnir-project/interface-manager": "4.2.6",
         "@the-draupnir-project/matrix-basic-types": "1.5.1",
         "@the-draupnir-project/mps-interface-adaptor": "0.6.0",
-        "@vector-im/matrix-bot-sdk": "^0.8.0-element.3",
+        "@vector-im/matrix-bot-sdk": "0.9.0-element.1",
         "better-sqlite3": "^12.8.0",
         "body-parser": "^1.20.2",
         "config": "^3.3.9",
@@ -3117,9 +3117,9 @@
       }
     },
     "node_modules/@matrix-org/matrix-sdk-crypto-nodejs": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/@matrix-org/matrix-sdk-crypto-nodejs/-/matrix-sdk-crypto-nodejs-0.4.0.tgz",
-      "integrity": "sha512-+qqgpn39XFSbsD0dFjssGO9vHEP7sTyfs8yTpt8vuqWpUpF20QMwpCZi0jpYw7GxjErNTsMshopuo8677DfGEA==",
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/@matrix-org/matrix-sdk-crypto-nodejs/-/matrix-sdk-crypto-nodejs-0.6.1.tgz",
+      "integrity": "sha512-xDulwTJfgHtA0rx/bi8JPc0m/hvImiuixfOoomUQYicBAi59xe8Cqc04K2GLQA+yc6JuqXfg6vLsNSgrStpLhw==",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -3127,7 +3127,7 @@
         "node-downloader-helper": "^2.1.9"
       },
       "engines": {
-        "node": ">= 22"
+        "node": ">= 24"
       }
     },
     "node_modules/@napi-rs/wasm-runtime": {
@@ -4647,12 +4647,12 @@
       ]
     },
     "node_modules/@vector-im/matrix-bot-sdk": {
-      "version": "0.8.0-element.3",
-      "resolved": "https://registry.npmjs.org/@vector-im/matrix-bot-sdk/-/matrix-bot-sdk-0.8.0-element.3.tgz",
-      "integrity": "sha512-2FFo/Kz2vTnOZDv59Q0s803LHf7KzuQ2EwOYYAtO0zUKJ8pV5CPsVC/IHyFb+Fsxl3R9XWFiX529yhslb4v9cQ==",
+      "version": "0.9.0-element.1",
+      "resolved": "https://registry.npmjs.org/@vector-im/matrix-bot-sdk/-/matrix-bot-sdk-0.9.0-element.1.tgz",
+      "integrity": "sha512-Tr96MVoVm1dagaz/hwJcncSXmk6el1ZmLAXTCK1vS+NwdEN6efJm2K1l47Dx1RyHWHi/CoKGRbMhI/g9+yO94w==",
       "license": "MIT",
       "dependencies": {
-        "@matrix-org/matrix-sdk-crypto-nodejs": "0.4.0",
+        "@matrix-org/matrix-sdk-crypto-nodejs": "^0.6.0",
         "@types/express": "^4.17.21",
         "@types/request": "^2.48.13",
         "another-json": "^0.2.0",
@@ -4662,7 +4662,6 @@
         "glob-to-regexp": "^0.4.1",
         "hash.js": "^1.1.7",
         "html-to-text": "^9.0.5",
-        "htmlencode": "^0.0.4",
         "lowdb": "1",
         "lru-cache": "^10.0.1",
         "mkdirp": "^3.0.1",
@@ -4673,7 +4672,7 @@
         "sanitize-html": "^2.11.0"
       },
       "engines": {
-        "node": ">=22.0.0"
+        "node": ">=24.0.0"
       }
     },
     "node_modules/@vector-im/matrix-bot-sdk/node_modules/lru-cache": {
@@ -5829,6 +5828,12 @@
       "engines": {
         "node": ">=18"
       }
+    },
+    "node_modules/dayjs": {
+      "version": "1.11.21",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.21.tgz",
+      "integrity": "sha512-98IT+HOahAisibz/yjKbzuOBwYcjJ7BCLPzARyHiyEBmRz4fatF+KPJszEHXsGYjUG234aH/cOjW1wwTbKUZlA==",
+      "license": "MIT"
     },
     "node_modules/debug": {
       "version": "4.4.3",
@@ -7400,12 +7405,6 @@
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
       }
-    },
-    "node_modules/htmlencode": {
-      "version": "0.0.4",
-      "resolved": "https://registry.npmjs.org/htmlencode/-/htmlencode-0.0.4.tgz",
-      "integrity": "sha512-0uDvNVpzj/E2TfvLLyyXhKBRvF1y84aZsyRxRXFsQobnHaL4pcaXk+Y9cnFlvnxrBLeXDNq/VJBD+ngdBgQG1w==",
-      "license": "MIT"
     },
     "node_modules/htmlparser2": {
       "version": "8.0.2",
@@ -10310,6 +10309,15 @@
       "integrity": "sha512-Xq9nH7KlWZmXAtodXDDRE7vs6DU1gTU8zYDHDiWLSip45Egwq3plLHzPn27NgvzL2r1LMPC1vdqh98sQxtqj4A==",
       "license": "MIT"
     },
+    "node_modules/launder": {
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/launder/-/launder-1.7.1.tgz",
+      "integrity": "sha512-mU6WRz5EusL9ZZuiZ5SO4Y6C0P9PAUR9iwdb6bzj4KDihm28DiHFw+/yk9DBH4f+Pv1wuzQ4e2jV3oQ7mkIqvw==",
+      "license": "MIT",
+      "dependencies": {
+        "dayjs": "^1.11.7"
+      }
+    },
     "node_modules/layerr": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/layerr/-/layerr-3.0.0.tgz",
@@ -10401,9 +10409,9 @@
       }
     },
     "node_modules/lodash": {
-      "version": "4.17.23",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
-      "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
       "license": "MIT"
     },
     "node_modules/lodash-es": {
@@ -10584,7 +10592,7 @@
       "dependencies": {
         "@alloc/quick-lru": "^5.2.0",
         "@types/nedb": "^1.8.16",
-        "@vector-im/matrix-bot-sdk": "0.8.0-element.3",
+        "@vector-im/matrix-bot-sdk": "0.9.0-element.1",
         "chalk": "^4.1.0",
         "express": "^4.18.2",
         "express-rate-limit": "^7.1.5",
@@ -11136,9 +11144,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.11",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
-      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "version": "3.3.16",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
+      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
       "funding": [
         {
           "type": "github",
@@ -11260,9 +11268,9 @@
       }
     },
     "node_modules/node-downloader-helper": {
-      "version": "2.1.10",
-      "resolved": "https://registry.npmjs.org/node-downloader-helper/-/node-downloader-helper-2.1.10.tgz",
-      "integrity": "sha512-8LdieUd4Bqw/CzfZLf30h+1xSAq3riWSDfWKsPJYz8EULoWxjS1vw6BGLYFZDxQgXjDR7UmC9UpQ0oV93U98Fg==",
+      "version": "2.1.11",
+      "resolved": "https://registry.npmjs.org/node-downloader-helper/-/node-downloader-helper-2.1.11.tgz",
+      "integrity": "sha512-882fH2C9AWdiPCwz/2beq5t8FGMZK9Dx8TJUOIxzMCbvG7XUKM5BuJwN5f0NKo4SCQK6jR4p2TPm54mYGdGchQ==",
       "license": "MIT",
       "bin": {
         "ndh": "bin/ndh"
@@ -11945,9 +11953,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.6",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
-      "integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
+      "version": "8.5.19",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.19.tgz",
+      "integrity": "sha512-Mz8SaolMd8nB+G13WkORcxQKHZ/NE4xXevtkJHVuG+guo9/wYKlIMTKAqGdEmYOXR2ijPjTYNHssizdaVSUNdQ==",
       "funding": [
         {
           "type": "opencollective",
@@ -11964,7 +11972,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.11",
+        "nanoid": "^3.3.12",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },
@@ -12687,17 +12695,122 @@
       "license": "MIT"
     },
     "node_modules/sanitize-html": {
-      "version": "2.17.1",
-      "resolved": "https://registry.npmjs.org/sanitize-html/-/sanitize-html-2.17.1.tgz",
-      "integrity": "sha512-ehFCW+q1a4CSOWRAdX97BX/6/PDEkCqw7/0JXZAGQV57FQB3YOkTa/rrzHPeJ+Aghy4vZAFfWMYyfxIiB7F/gw==",
+      "version": "2.17.6",
+      "resolved": "https://registry.npmjs.org/sanitize-html/-/sanitize-html-2.17.6.tgz",
+      "integrity": "sha512-M4bo9tfv1yfhQZZKkc6dL07ALrGJtfvNOuhX3hU9AVPR/uPQ+nKOJBqTYc7LfMQblTW04mtSWDJWEyLvygJsLA==",
       "license": "MIT",
       "dependencies": {
         "deepmerge": "^4.2.2",
         "escape-string-regexp": "^4.0.0",
-        "htmlparser2": "^8.0.0",
+        "htmlparser2": "^12.0.0",
         "is-plain-object": "^5.0.0",
+        "launder": "^1.7.1",
         "parse-srcset": "^1.0.2",
         "postcss": "^8.3.11"
+      },
+      "engines": {
+        "node": ">=22.12.0"
+      }
+    },
+    "node_modules/sanitize-html/node_modules/dom-serializer": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-3.1.1.tgz",
+      "integrity": "sha512-4MEa38/QexBob6gFNwu+EGdWvhJ1OKuNwdYY3Y3NyeWDQfnGeDYQUDfIRzWu5B5gsv03so2Uxd28YC6zrsx3Lw==",
+      "license": "MIT",
+      "dependencies": {
+        "domelementtype": "^3.0.0",
+        "domhandler": "^6.0.0",
+        "entities": "^8.0.0"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
+      }
+    },
+    "node_modules/sanitize-html/node_modules/domelementtype": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-3.0.0.tgz",
+      "integrity": "sha512-umCQid3jKbDmVjx8jGaW7uUykm4DEUeyV21hPxNMo2nV955DhUThwqyOIDtreepP31hl84X7G5U9ZfsWvIB3Pg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
+    "node_modules/sanitize-html/node_modules/domhandler": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-6.0.1.tgz",
+      "integrity": "sha512-gYzvtM72ZtxQO0T048kd6HWSbbGCNOUwcnfQ01cqIJ4X2IYKFFHZ5mKvrQETcFXxsRObZulDaKmy//R7TPtsBg==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "domelementtype": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/fb55/domhandler?sponsor=1"
+      }
+    },
+    "node_modules/sanitize-html/node_modules/domutils": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/domutils/-/domutils-4.0.2.tgz",
+      "integrity": "sha512-qI4JLRKnSzqFqr7hAlS5xQDusBCjKSEG4t4+7aNrIQMHBcsC2TGEhuyABJdYkgSewL57PNLYEiibY2iPKhKpaA==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "dom-serializer": "^3.0.0",
+        "domelementtype": "^3.0.0",
+        "domhandler": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/fb55/domutils?sponsor=1"
+      }
+    },
+    "node_modules/sanitize-html/node_modules/entities": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-8.0.0.tgz",
+      "integrity": "sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/sanitize-html/node_modules/htmlparser2": {
+      "version": "12.0.0",
+      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-12.0.0.tgz",
+      "integrity": "sha512-Tz7u1i95/g2x2jz81+x0FBVhBhY5aRTvD3tXXdFaljuNdzDLJ8UGNRrTcj2cgQvAg3iW/h77Fz15nLW0L0CrZw==",
+      "funding": [
+        "https://github.com/fb55/htmlparser2?sponsor=1",
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "domelementtype": "^3.0.0",
+        "domhandler": "^6.0.0",
+        "domutils": "^4.0.2",
+        "entities": "^8.0.0"
+      },
+      "engines": {
+        "node": ">=20.19.0"
       }
     },
     "node_modules/saxes": {
@@ -14079,7 +14192,7 @@
       "version": "3.4.0",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
       "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
-      "deprecated": "Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.",
+      "deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
       "license": "MIT",
       "bin": {
         "uuid": "bin/uuid"
@@ -14662,14 +14775,14 @@
         "@types/crypto-js": "^4.1.2",
         "@types/glob-to-regexp": "^0.4.1",
         "@types/node": "^24.12.4",
-        "@vector-im/matrix-bot-sdk": "0.8.0-element.3",
+        "@vector-im/matrix-bot-sdk": "0.9.0-element.1",
         "matrix-protection-suite": "npm:@the-draupnir-project/matrix-protection-suite@7.1.0",
         "typedoc": "^0.26.3"
       },
       "peerDependencies": {
         "@sinclair/typebox": "0.34.49",
         "@the-draupnir-project/matrix-basic-types": "1.5.1",
-        "@vector-im/matrix-bot-sdk": "^0.8.0-element.3",
+        "@vector-im/matrix-bot-sdk": "^0.9.0-element.1",
         "matrix-protection-suite": "npm:@the-draupnir-project/matrix-protection-suite@7.1.0"
       }
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -45,7 +45,7 @@
         "html-to-text": "^8.0.0",
         "js-yaml": "^4.1.0",
         "jsdom": "^24.0.0",
-        "matrix-appservice-bridge": "^11.2.0",
+        "matrix-appservice-bridge": "11.2.0",
         "matrix-protection-suite": "npm:@the-draupnir-project/matrix-protection-suite@7.1.0",
         "matrix-protection-suite-for-matrix-bot-sdk": "npm:@the-draupnir-project/matrix-protection-suite@5.0.1",
         "pg": "^8.8.0",

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "typescript-eslint": "^8.56.1"
   },
   "overrides": {
+    "@matrix-org/matrix-sdk-crypto-nodejs": "0.4.0",
     "@vector-im/matrix-bot-sdk": "0.8.0-element.3",
     "postgres": "3.4.7"
   },

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "typescript-eslint": "^8.56.1"
   },
   "overrides": {
-    "@matrix-org/matrix-sdk-crypto-nodejs": "0.4.0",
+    "@matrix-org/matrix-sdk-crypto-nodejs": "0.6.1",
     "@vector-im/matrix-bot-sdk": "0.8.0-element.3",
     "postgres": "3.4.7"
   },

--- a/package.json
+++ b/package.json
@@ -35,8 +35,7 @@
     "typescript-eslint": "^8.56.1"
   },
   "overrides": {
-    "@matrix-org/matrix-sdk-crypto-nodejs": "0.6.1",
-    "@vector-im/matrix-bot-sdk": "0.8.0-element.3",
+    "@vector-im/matrix-bot-sdk": "0.9.0-element.1",
     "postgres": "3.4.7"
   },
   "engines": {

--- a/packages/matrix-protection-suite-for-matrix-bot-sdk/package.json
+++ b/packages/matrix-protection-suite-for-matrix-bot-sdk/package.json
@@ -25,7 +25,7 @@
     "@types/crypto-js": "^4.1.2",
     "@types/glob-to-regexp": "^0.4.1",
     "@types/node": "^24.12.4",
-    "@vector-im/matrix-bot-sdk": "0.8.0-element.3",
+    "@vector-im/matrix-bot-sdk": "0.9.0-element.1",
     "matrix-protection-suite": "npm:@the-draupnir-project/matrix-protection-suite@7.1.0",
     "typedoc": "^0.26.3"
   },
@@ -36,7 +36,7 @@
   "peerDependencies": {
     "@sinclair/typebox": "0.34.49",
     "@the-draupnir-project/matrix-basic-types": "1.5.1",
-    "@vector-im/matrix-bot-sdk": "^0.8.0-element.3",
+    "@vector-im/matrix-bot-sdk": "^0.9.0-element.1",
     "matrix-protection-suite": "npm:@the-draupnir-project/matrix-protection-suite@7.1.0"
   },
   "publishConfig": {


### PR DESCRIPTION
It is causing CI failures because we explicitly do not use npm ci in this workflow so that we can detect inconsistencies. It's not exactly clear to me how 0.6.0 is being pulled in vs 0.4.0 though.