### PR TITLE
Fix Workflows double firing for merge queues.

### DIFF
--- a/.github/workflows/ci-in-a-box.yml
+++ b/.github/workflows/ci-in-a-box.yml
@@ -9,6 +9,7 @@ on:
   push:
     branches-ignore:
       - "github-actions/**"
+      - "gh-readonly-queue/**"
   schedule:
     - cron: "20 20 * * *"
   pull_request:

--- a/.github/workflows/validate-docker-build.yml
+++ b/.github/workflows/validate-docker-build.yml
@@ -11,6 +11,7 @@ on:
     branches-ignore:
       - "dependabot/**"
       - "github-actions/**"
+      - "gh-readonly-queue/**"
   schedule:
     - cron: "20 20 * * *"
   pull_request:


### PR DESCRIPTION
This happened due to on push triggers that did not exclude the ephemeral merge queue branches.